### PR TITLE
num cpus

### DIFF
--- a/queue/queue.go
+++ b/queue/queue.go
@@ -1,11 +1,9 @@
 package queue
 
 import (
-	"log"
 	"runtime"
 	"sync"
 	"sync/atomic"
-	"time"
 )
 
 type waiters []*sema
@@ -242,7 +240,6 @@ func ExecuteInParallel(q *Queue, fn func(interface{})) {
 
 	var wg sync.WaitGroup
 	wg.Add(1)
-	t0 := time.Now()
 
 	numCPU := 1
 	if runtime.NumCPU() > 1 {
@@ -269,6 +266,4 @@ func ExecuteInParallel(q *Queue, fn func(interface{})) {
 
 	wg.Wait()
 	q.Dispose()
-
-	log.Printf(`PARALLEL TOOK: %d ms`, time.Since(t0).Nanoseconds()/int64(time.Millisecond))
 }


### PR DESCRIPTION
CODE REVIEW

After doing some experimentation over large calcs, setting the goroutines here to runtime.NumCPU() - 1 if more than 1 cpu appears to provide the best performance.  It has basically taken the gen3 test import from ~900ms to ~850ms.  Not too bad for such a small change.

@beaulyddon-wf @tannermiller-wf @alexandercampbell-wf @rosshendrickson-wf @stevenosborne-wf @tylertreat-wf @ericolson-wf 
