### PR TITLE
B plus tree

### DIFF
--- a/btree/plus/btree.go
+++ b/btree/plus/btree.go
@@ -1,0 +1,38 @@
+package plus
+
+func keySearch(keys keys, key Key) int {
+	low, high := 0, len(keys)-1
+	var mid int
+	for low <= high {
+		mid = (high + low) / 2
+		switch keys[mid].Compare(key) {
+		case 1:
+			low = mid + 1
+		case -1:
+			high = mid - 1
+		case 0:
+			return mid
+		}
+	}
+	return low
+}
+
+type btree struct {
+	root             node
+	nodeSize, number uint64
+}
+
+func (tree *btree) insert(key Key) {
+	tree.root.insert(tree, key)
+}
+
+func (tree *btree) Insert(keys ...Key) {
+
+}
+
+func newBTree(nodeSize uint64) *btree {
+	return &btree{
+		nodeSize: nodeSize,
+		root:     newLeafNode(nodeSize),
+	}
+}

--- a/btree/plus/btree.go
+++ b/btree/plus/btree.go
@@ -47,6 +47,14 @@ func (tree *btree) Insert(keys ...Key) {
 	}
 }
 
+func (tree *btree) Iterate(key Key) *iterator {
+	if tree.root == nil {
+		return nilIterator()
+	}
+
+	return tree.root.find(key)
+}
+
 func newBTree(nodeSize uint64) *btree {
 	return &btree{
 		nodeSize: nodeSize,

--- a/btree/plus/btree.go
+++ b/btree/plus/btree.go
@@ -36,7 +36,6 @@ func (tree *btree) insert(key Key) {
 	}
 
 	if tree.root.needsSplit(tree.nodeSize) {
-		println(`calling split here`)
 		tree.root = split(tree, nil, tree.root)
 	}
 }

--- a/btree/plus/btree.go
+++ b/btree/plus/btree.go
@@ -23,11 +23,28 @@ type btree struct {
 }
 
 func (tree *btree) insert(key Key) {
-	tree.root.insert(tree, key)
+	if tree.root == nil {
+		n := newLeafNode(tree.nodeSize)
+		n.insert(tree, key)
+		tree.number = 1
+		return
+	}
+
+	result := tree.root.insert(tree, key)
+	if result {
+		tree.number++
+	}
+
+	if tree.root.needsSplit(tree.nodeSize) {
+		println(`calling split here`)
+		tree.root = split(tree, nil, tree.root)
+	}
 }
 
 func (tree *btree) Insert(keys ...Key) {
-
+	for _, key := range keys {
+		tree.insert(key)
+	}
 }
 
 func newBTree(nodeSize uint64) *btree {

--- a/btree/plus/btree_test.go
+++ b/btree/plus/btree_test.go
@@ -147,3 +147,18 @@ func TestTreeInsert3_4_5WithEarlyDuplicate(t *testing.T) {
 
 	assert.Equal(t, keys, result)
 }
+
+func TestTreeInsert3_4_5WithDuplicateID(t *testing.T) {
+	tree := newBTree(4)
+	keys := constructMockKeys(5)
+
+	key := newMockKey(2, 2)
+	tree.Insert(keys...)
+	println(`SHIT STARTS HERE`)
+	tree.Insert(key)
+
+	iter := tree.Iterate(newMockKey(0, 0))
+	result := iter.exhaust()
+
+	assert.Equal(t, keys, result)
+}

--- a/btree/plus/btree_test.go
+++ b/btree/plus/btree_test.go
@@ -23,3 +23,14 @@ func TestSearchKeys(t *testing.T) {
 
 	assert.Equal(t, 0, keySearch(nil, testKey))
 }
+
+func TestTreeInsert(t *testing.T) {
+	tree := newBTree(3)
+	keys := constructMockKeys(4)
+
+	tree.Insert(keys...)
+
+	assert.Len(t, tree.root.(*inode).keys, 2)
+	assert.Len(t, tree.root.(*inode).nodes, 3)
+	assert.IsType(t, &inode{}, tree.root)
+}

--- a/btree/plus/btree_test.go
+++ b/btree/plus/btree_test.go
@@ -154,11 +154,46 @@ func TestTreeInsert3_4_5WithDuplicateID(t *testing.T) {
 
 	key := newMockKey(2, 2)
 	tree.Insert(keys...)
-	println(`SHIT STARTS HERE`)
 	tree.Insert(key)
 
 	iter := tree.Iterate(newMockKey(0, 0))
 	result := iter.exhaust()
 
 	assert.Equal(t, keys, result)
+}
+
+func TestTreeInsert3_4_5MiddleQuery(t *testing.T) {
+	tree := newBTree(4)
+	keys := constructMockKeys(5)
+
+	tree.Insert(keys...)
+
+	iter := tree.Iterate(newMockKey(2, 0))
+	result := iter.exhaust()
+
+	assert.Equal(t, keys[2:], result)
+}
+
+func TestTreeInsert3_4_5LateQuery(t *testing.T) {
+	tree := newBTree(4)
+	keys := constructMockKeys(5)
+
+	tree.Insert(keys...)
+
+	iter := tree.Iterate(newMockKey(4, 0))
+	result := iter.exhaust()
+
+	assert.Equal(t, keys[4:], result)
+}
+
+func TestTreeInsert3_4_5AfterQuery(t *testing.T) {
+	tree := newBTree(4)
+	keys := constructMockKeys(5)
+
+	tree.Insert(keys...)
+
+	iter := tree.Iterate(newMockKey(5, 0))
+	result := iter.exhaust()
+
+	assert.Len(t, result, 0)
 }

--- a/btree/plus/btree_test.go
+++ b/btree/plus/btree_test.go
@@ -104,3 +104,46 @@ func TestTreeInsertReverseOrder3_4_5(t *testing.T) {
 
 	assert.Equal(t, keys, result)
 }
+
+func TestTreeInsert3_4_5_WithEndDuplicate(t *testing.T) {
+	tree := newBTree(4)
+	keys := constructMockKeys(5)
+
+	keys = append(keys, newMockKey(4, 5))
+	tree.Insert(keys...)
+
+	iter := tree.Iterate(newMockKey(0, 0))
+	result := iter.exhaust()
+
+	assert.Equal(t, keys, result)
+}
+
+func TestTreeInsert3_4_5_WithMiddleDuplicate(t *testing.T) {
+	tree := newBTree(4)
+	keys := constructMockKeys(5)
+
+	key := newMockKey(2, 5)
+	keys.insertAt(3, key)
+
+	tree.Insert(keys...)
+
+	iter := tree.Iterate(newMockKey(0, 0))
+	result := iter.exhaust()
+
+	assert.Equal(t, keys, result)
+}
+
+func TestTreeInsert3_4_5WithEarlyDuplicate(t *testing.T) {
+	tree := newBTree(4)
+	keys := constructMockKeys(5)
+
+	key := newMockKey(0, 5)
+	keys.insertAt(1, key)
+
+	tree.Insert(keys...)
+
+	iter := tree.Iterate(newMockKey(0, 0))
+	result := iter.exhaust()
+
+	assert.Equal(t, keys, result)
+}

--- a/btree/plus/btree_test.go
+++ b/btree/plus/btree_test.go
@@ -62,3 +62,45 @@ func TestTreeInsertQuery2_3_4(t *testing.T) {
 
 	assert.Equal(t, keys, result)
 }
+
+func TestTreeInsertQuery3_4_5(t *testing.T) {
+	tree := newBTree(4)
+	keys := constructMockKeys(5)
+
+	tree.Insert(keys...)
+
+	iter := tree.Iterate(newMockKey(0, 0))
+	result := iter.exhaust()
+
+	assert.Equal(t, keys, result)
+}
+
+func TestTreeInsertReverseOrder2_3_4(t *testing.T) {
+	tree := newBTree(3)
+	keys := constructMockKeys(4)
+	keys.reverse()
+
+	tree.Insert(keys...)
+
+	iter := tree.Iterate(newMockKey(0, 0))
+	result := iter.exhaust()
+	keys.reverse() // we want to fetch things in the correct
+	// ascending order
+
+	assert.Equal(t, keys, result)
+}
+
+func TestTreeInsertReverseOrder3_4_5(t *testing.T) {
+	tree := newBTree(4)
+	keys := constructMockKeys(5)
+	keys.reverse()
+
+	tree.Insert(keys...)
+
+	iter := tree.Iterate(newMockKey(0, 0))
+	result := iter.exhaust()
+	keys.reverse() // we want to fetch things in the correct
+	// ascending order
+
+	assert.Equal(t, keys, result)
+}

--- a/btree/plus/btree_test.go
+++ b/btree/plus/btree_test.go
@@ -197,3 +197,49 @@ func TestTreeInsert3_4_5AfterQuery(t *testing.T) {
 
 	assert.Len(t, result, 0)
 }
+
+func TestTreeInternalNodeSplit(t *testing.T) {
+	tree := newBTree(4)
+	keys := constructMockKeys(10)
+
+	tree.Insert(keys...)
+
+	iter := tree.Iterate(newMockKey(0, 0))
+	result := iter.exhaust()
+
+	assert.Equal(t, keys, result)
+}
+
+func TestTreeInternalNodeSplitReverseOrder(t *testing.T) {
+	tree := newBTree(4)
+	keys := constructMockKeys(10)
+	keys.reverse()
+
+	tree.Insert(keys...)
+
+	iter := tree.Iterate(newMockKey(0, 0))
+	result := iter.exhaust()
+	keys.reverse()
+
+	assert.Equal(t, keys, result)
+}
+
+func TestTreeInternalNodeSplitRandomOrder(t *testing.T) {
+	ids := []uint64{6, 2, 9, 0, 3, 4, 7, 1, 8, 5}
+	keys := make(keys, 0, len(ids))
+
+	for _, id := range ids {
+		keys = append(keys, newMockKey(id, id))
+	}
+
+	tree := newBTree(4)
+	tree.Insert(keys...)
+
+	iter := tree.Iterate(newMockKey(0, 0))
+	result := iter.exhaust()
+
+	assert.Len(t, result, 10)
+	for i, key := range result {
+		assert.Equal(t, newMockKey(uint64(i), uint64(i)), key)
+	}
+}

--- a/btree/plus/btree_test.go
+++ b/btree/plus/btree_test.go
@@ -243,3 +243,23 @@ func TestTreeInternalNodeSplitRandomOrder(t *testing.T) {
 		assert.Equal(t, newMockKey(uint64(i), uint64(i)), key)
 	}
 }
+
+func TestTreeRandomOrderQuery(t *testing.T) {
+	ids := []uint64{6, 2, 9, 0, 3, 4, 7, 1, 8, 5}
+	keys := make(keys, 0, len(ids))
+
+	for _, id := range ids {
+		keys = append(keys, newMockKey(id, id))
+	}
+
+	tree := newBTree(4)
+	tree.Insert(keys...)
+
+	iter := tree.Iterate(newMockKey(4, 4))
+	result := iter.exhaust()
+
+	assert.Len(t, result, 6)
+	for i, key := range result {
+		assert.Equal(t, newMockKey(uint64(i)+4, uint64(i)+4), key)
+	}
+}

--- a/btree/plus/btree_test.go
+++ b/btree/plus/btree_test.go
@@ -1,10 +1,15 @@
 package plus
 
 import (
+	"log"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func init() {
+	log.Print(`hate this`)
+}
 
 func TestSearchKeys(t *testing.T) {
 	keys := keys{newMockKey(1, 1), newMockKey(2, 2), newMockKey(4, 4)}
@@ -24,7 +29,7 @@ func TestSearchKeys(t *testing.T) {
 	assert.Equal(t, 0, keySearch(nil, testKey))
 }
 
-func TestTreeInsert(t *testing.T) {
+func TestTreeInsert2_3_4(t *testing.T) {
 	tree := newBTree(3)
 	keys := constructMockKeys(4)
 
@@ -33,4 +38,27 @@ func TestTreeInsert(t *testing.T) {
 	assert.Len(t, tree.root.(*inode).keys, 2)
 	assert.Len(t, tree.root.(*inode).nodes, 3)
 	assert.IsType(t, &inode{}, tree.root)
+}
+
+func TestTreeInsert3_4_5(t *testing.T) {
+	tree := newBTree(4)
+	keys := constructMockKeys(5)
+
+	tree.Insert(keys...)
+
+	assert.Len(t, tree.root.(*inode).keys, 1)
+	assert.Len(t, tree.root.(*inode).nodes, 2)
+	assert.IsType(t, &inode{}, tree.root)
+}
+
+func TestTreeInsertQuery2_3_4(t *testing.T) {
+	tree := newBTree(3)
+	keys := constructMockKeys(4)
+
+	tree.Insert(keys...)
+
+	iter := tree.Iterate(newMockKey(0, 0))
+	result := iter.exhaust()
+
+	assert.Equal(t, keys, result)
 }

--- a/btree/plus/btree_test.go
+++ b/btree/plus/btree_test.go
@@ -263,3 +263,33 @@ func TestTreeRandomOrderQuery(t *testing.T) {
 		assert.Equal(t, newMockKey(uint64(i)+4, uint64(i)+4), key)
 	}
 }
+
+func BenchmarkIteration(b *testing.B) {
+	numItems := uint64(1000)
+	ary := uint64(16)
+
+	keys := constructMockKeys(numItems)
+	tree := newBTree(ary)
+	tree.Insert(keys...)
+
+	searchKey := newMockKey(0, 0)
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		iter := tree.Iterate(searchKey)
+		iter.exhaust()
+	}
+}
+
+func BenchmarkInsert(b *testing.B) {
+	numItems := uint64(1000)
+	ary := uint64(16)
+
+	keys := constructMockKeys(numItems)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		tree := newBTree(ary)
+		tree.Insert(keys...)
+	}
+}

--- a/btree/plus/btree_test.go
+++ b/btree/plus/btree_test.go
@@ -1,0 +1,25 @@
+package plus
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSearchKeys(t *testing.T) {
+	keys := keys{newMockKey(1, 1), newMockKey(2, 2), newMockKey(4, 4)}
+
+	testKey := newMockKey(5, 5)
+	assert.Equal(t, 3, keySearch(keys, testKey))
+
+	testKey = newMockKey(2, 2)
+	assert.Equal(t, 1, keySearch(keys, testKey))
+
+	testKey = newMockKey(0, 0)
+	assert.Equal(t, 0, keySearch(keys, testKey))
+
+	testKey = newMockKey(3, 3)
+	assert.Equal(t, 2, keySearch(keys, testKey))
+
+	assert.Equal(t, 0, keySearch(nil, testKey))
+}

--- a/btree/plus/interface.go
+++ b/btree/plus/interface.go
@@ -1,0 +1,12 @@
+package plus
+
+type Key interface {
+	// Compare should return an int indicating how this key relates
+	// to the provided key.  -1 will indicate less than, 0 will indicate
+	// equality, and 1 will indicate greater than.  Duplicate keys
+	// are allowed, but duplicate IDs are not.
+	Compare(Key) int
+	// ID should be a unique identifier for this key.  Keys that are
+	// identical including IDs will not be inserted.
+	ID() uint64
+}

--- a/btree/plus/interface.go
+++ b/btree/plus/interface.go
@@ -10,3 +10,10 @@ type Key interface {
 	// identical including IDs will not be inserted.
 	ID() uint64
 }
+
+// Iterator will be called with matching keys until either false is
+// returned or we run out of keys to iterate.
+type Iterator interface {
+	Next() bool
+	Value() Key
+}

--- a/btree/plus/iterator.go
+++ b/btree/plus/iterator.go
@@ -60,7 +60,6 @@ func (iter *iterator) Next() bool {
 }
 
 func (iter *iterator) Value() Key {
-	log.Printf(`iter: %+v`, iter.pi.value())
 	return iter.pi.value()
 }
 

--- a/btree/plus/iterator.go
+++ b/btree/plus/iterator.go
@@ -1,0 +1,81 @@
+package plus
+
+import "log"
+
+func init() {
+	log.Printf(`test`)
+}
+
+type payloadIterator struct {
+	keys  sortedByIDKeys
+	index int
+}
+
+func (pi *payloadIterator) next() bool {
+	pi.index++
+	if pi.index >= len(pi.keys) {
+		return false
+	}
+
+	return true
+}
+
+func (pi *payloadIterator) value() Key {
+	return pi.keys[pi.index]
+}
+
+type iterator struct {
+	node  *lnode
+	index int
+	pi    *payloadIterator
+}
+
+func (iter *iterator) Next() bool {
+	if iter.index == -2 {
+		return false
+	}
+
+	if iter.pi != nil {
+		if iter.pi.next() {
+			return true
+		}
+		iter.pi = nil
+	}
+
+	iter.index++
+	if iter.index >= len(iter.node.keys) {
+		iter.node = iter.node.pointer
+		if iter.node == nil {
+			iter.index = -2
+			return false
+		}
+		iter.index = 0
+	}
+
+	iter.pi = &payloadIterator{
+		keys:  iter.node.keys[iter.index].(*payload).keys,
+		index: -1,
+	}
+	return iter.pi.next()
+}
+
+func (iter *iterator) Value() Key {
+	log.Printf(`iter: %+v`, iter.pi.value())
+	return iter.pi.value()
+}
+
+// exhaust is a test function that's not exported
+func (iter *iterator) exhaust() keys {
+	keys := make(keys, 0, 10)
+	for iter := iter; iter.Next(); {
+		keys = append(keys, iter.Value())
+	}
+
+	return keys
+}
+
+func nilIterator() *iterator {
+	return &iterator{
+		index: -2,
+	}
+}

--- a/btree/plus/mock_test.go
+++ b/btree/plus/mock_test.go
@@ -1,0 +1,25 @@
+package plus
+
+type mockKey struct {
+	value, id uint64
+}
+
+func (mk *mockKey) ID() uint64 {
+	return mk.id
+}
+
+func (mk *mockKey) Compare(other Key) int {
+	key := other.(*mockKey)
+	if key.value == mk.value {
+		return 0
+	}
+	if key.value > mk.value {
+		return 1
+	}
+
+	return -1
+}
+
+func newMockKey(value, id uint64) *mockKey {
+	return &mockKey{value, id}
+}

--- a/btree/plus/node.go
+++ b/btree/plus/node.go
@@ -1,0 +1,118 @@
+package plus
+
+import "sort"
+
+type node interface {
+	insert(tree *btree, key Key) bool
+}
+
+type nodes []node
+
+type inode struct {
+	keys  keys
+	nodes nodes
+}
+
+type lnode struct {
+	// points to the left leaf node is there is one
+	pointer *lnode
+	keys    keys
+}
+
+func (lnode *lnode) insert(tree *btree, key Key) bool {
+	i := keySearch(lnode.keys, key)
+	var inserted bool
+	if i == len(lnode.keys) { // simple append will do
+		lnode.keys = append(lnode.keys, newPayload(key))
+		inserted = true
+	} else {
+		if lnode.keys[i].Compare(key) == 0 {
+			inserted = lnode.keys[i].(*payload).insert(key)
+		} else {
+			lnode.keys.insertAt(i, newPayload(key))
+			inserted = true
+		}
+	}
+
+	if !inserted {
+		return false
+	}
+
+	if uint64(len(lnode.keys)) == tree.nodeSize { // all the magic happens here
+
+	}
+
+	return true
+}
+
+func newLeafNode(size uint64) *lnode {
+	return &lnode{
+		keys: make(keys, 0, size),
+	}
+}
+
+type payload struct {
+	keys sortedByIDKeys
+}
+
+func (payload *payload) insert(key Key) bool {
+	return payload.keys.insert(key)
+}
+
+func (payload *payload) ID() uint64 {
+	return 0
+}
+
+func (payload *payload) Compare(key Key) int {
+	if len(payload.keys) == 0 {
+		panic(`WE HAVE A PAYLOAD WITH NO KEYS`)
+	}
+
+	return payload.keys[0].Compare(key)
+}
+
+func newPayload(key Key) *payload {
+	p := &payload{
+		keys: make(sortedByIDKeys, 0, 5),
+	}
+	p.keys = append(p.keys, key)
+	return p
+}
+
+type keys []Key
+
+func (keys *keys) insertAt(i int, key Key) {
+	if i == len(*keys) {
+		*keys = append(*keys, key)
+		return
+	}
+
+	*keys = append(*keys, nil)
+	copy((*keys)[i+1:], (*keys)[i:])
+	(*keys)[i] = key
+}
+
+type sortedByIDKeys keys
+
+func (sorted sortedByIDKeys) search(id uint64) int {
+	return sort.Search(len(sorted), func(i int) bool {
+		return sorted[i].ID() >= id
+	})
+}
+
+func (sorted *sortedByIDKeys) insert(key Key) bool {
+	i := sorted.search(key.ID())
+	if i == len(*sorted) {
+		*sorted = append(*sorted, key)
+		return true
+	}
+
+	if (*sorted)[i].ID() == key.ID() { // we don't allow duplicates
+		return false
+	}
+
+	*sorted = append(*sorted, nil)
+	copy((*sorted)[i+1:], (*sorted)[i:])
+	(*sorted)[i] = key
+	return true
+}

--- a/btree/plus/node.go
+++ b/btree/plus/node.go
@@ -23,10 +23,6 @@ func split(tree *btree, parent, child node) node {
 		return in
 	}
 
-	log.Printf(`left: %+v`, left)
-	log.Printf(`right: %+v`, right)
-	log.Printf(`key: %+v`, key)
-
 	p := parent.(*inode)
 	i := p.search(key)
 	// we want to ensure if the children are leaves we set
@@ -314,7 +310,6 @@ func (sorted *sortedByIDKeys) insert(key Key) bool {
 	}
 
 	if (*sorted)[i].ID() == key.ID() { // we don't allow duplicates
-		println(`RETURNING FALSE`)
 		return false
 	}
 

--- a/btree/plus/node.go
+++ b/btree/plus/node.go
@@ -295,6 +295,12 @@ func (keys *keys) insertAt(i int, key Key) {
 	(*keys)[i] = key
 }
 
+func (keys keys) reverse() {
+	for i := 0; i < len(keys)/2; i++ {
+		keys[i], keys[len(keys)-i-1] = keys[len(keys)-i-1], keys[i]
+	}
+}
+
 type sortedByIDKeys keys
 
 func (sorted sortedByIDKeys) search(id uint64) int {

--- a/btree/plus/node.go
+++ b/btree/plus/node.go
@@ -14,11 +14,26 @@ func split(tree *btree, parent, child node) node {
 		return parent
 	}
 
-	switch child.(type) {
-	case *lnode: // we need to split a leaf
-
+	key, left, right := child.split()
+	if parent == nil {
+		in := newInternalNode(tree.nodeSize)
+		in.keys = append(in.keys, key)
+		in.nodes = append(in.nodes, left)
+		in.nodes = append(in.nodes, right)
+		return in
 	}
-	return nil
+
+	log.Printf(`left: %+v`, left)
+	log.Printf(`right: %+v`, right)
+	log.Printf(`key: %+v`, key)
+
+	p := parent.(*inode)
+	i := p.search(key)
+	p.keys.insertAt(i, key)
+	p.nodes[i] = left
+	p.nodes.insertAt(i+1, right)
+
+	return parent
 }
 
 type node interface {
@@ -116,7 +131,7 @@ func (n *inode) split() (Key, node, node) {
 func newInternalNode(size uint64) *inode {
 	return &inode{
 		keys:  make(keys, 0, size),
-		nodes: make(nodes, 0, size),
+		nodes: make(nodes, 0, size+1),
 	}
 }
 

--- a/btree/plus/node.go
+++ b/btree/plus/node.go
@@ -85,14 +85,13 @@ func (node *inode) search(key Key) int {
 
 func (node *inode) find(key Key) *iterator {
 	i := node.search(key)
-	log.Printf(`INODE FIND: %+v, i: %d`, node, i)
 	if i == len(node.keys) {
 		return node.nodes[len(node.nodes)-1].find(key)
 	}
 
 	found := node.keys[i]
 	switch found.Compare(key) {
-	case 0 | 1:
+	case 0, 1:
 		return node.nodes[i+1].find(key)
 	default:
 		return node.nodes[i].find(key)
@@ -107,7 +106,7 @@ func (n *inode) insert(tree *btree, key Key) bool {
 	} else {
 		match := n.keys[i]
 		switch match.Compare(key) {
-		case 1 | 0:
+		case 1, 0:
 			child = n.nodes[i+1]
 		default:
 			child = n.nodes[i]
@@ -193,7 +192,6 @@ func (lnode *lnode) insert(tree *btree, key Key) bool {
 
 func (node *lnode) find(key Key) *iterator {
 	i := node.search(key)
-	log.Printf(`LEAF FIND: %+v, i: %d`, node, i)
 	if i == len(node.keys) {
 		if node.pointer == nil {
 			return nilIterator()
@@ -209,7 +207,6 @@ func (node *lnode) find(key Key) *iterator {
 		node:  node,
 		index: i - 1,
 	}
-	log.Printf(`ITER: %+v`, iter)
 	return iter
 }
 
@@ -317,6 +314,7 @@ func (sorted *sortedByIDKeys) insert(key Key) bool {
 	}
 
 	if (*sorted)[i].ID() == key.ID() { // we don't allow duplicates
+		println(`RETURNING FALSE`)
 		return false
 	}
 

--- a/btree/plus/node_test.go
+++ b/btree/plus/node_test.go
@@ -1,0 +1,45 @@
+package plus
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNodeInsert(t *testing.T) {
+	tree := newBTree(3)
+	n := newLeafNode(3)
+	key := newMockKey(3, 3)
+
+	n.insert(tree, key)
+
+	assert.Len(t, n.keys, 1)
+	assert.Nil(t, n.pointer)
+	assert.Equal(t, n.keys[0].(*payload).keys[0], key)
+	assert.Equal(t, 0, n.keys[0].Compare(key))
+}
+
+func TestDuplicateNodeInsert(t *testing.T) {
+	tree := newBTree(3)
+	n := newLeafNode(3)
+	k1 := newMockKey(3, 3)
+	k2 := newMockKey(3, 4)
+
+	n.insert(tree, k1)
+	n.insert(tree, k2)
+	n.insert(tree, k1)
+
+	assert.Len(t, n.keys, 1)
+	assert.Nil(t, n.pointer)
+	if !assert.Len(t, n.keys[0].(*payload).keys, 2) {
+		return
+	}
+	assert.Equal(t, n.keys[0].(*payload).keys[0], k1)
+	assert.Equal(t, n.keys[0].(*payload).keys[1], k2)
+	assert.Equal(t, 0, n.keys[0].Compare(k1))
+	assert.Equal(t, 0, n.keys[0].Compare(k2))
+}
+
+func TestMultipleNodeInsert(t *testing.T) {
+
+}

--- a/btree/plus/node_test.go
+++ b/btree/plus/node_test.go
@@ -197,3 +197,13 @@ func TestInternalNodeSplit3_4_5(t *testing.T) {
 	assert.Equal(t, nodes[:3], left.(*inode).nodes)
 	assert.Equal(t, nodes[3:], right.(*inode).nodes)
 }
+
+func TestInternalNodeLessThan3Keys(t *testing.T) {
+	nodes := constructMockNodes(2)
+	in := constructMockInternalNode(nodes)
+
+	key, left, right := in.split()
+	assert.Nil(t, key)
+	assert.Nil(t, left)
+	assert.Nil(t, right)
+}

--- a/btree/plus/node_test.go
+++ b/btree/plus/node_test.go
@@ -6,7 +6,26 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNodeInsert(t *testing.T) {
+func constructMockPayloads(num uint64) keys {
+	keys := make(keys, 0, num)
+	for i := uint64(0); i < num; i++ {
+		keys = append(keys, newPayload(newMockKey(i, i)))
+	}
+
+	return keys
+}
+
+func constructMockKeys(num uint64) keys {
+	keys := make(keys, 0, num)
+
+	for i := uint64(0); i < num; i++ {
+		keys = append(keys, newMockKey(i, i))
+	}
+
+	return keys
+}
+
+func TestLeafNodeInsert(t *testing.T) {
 	tree := newBTree(3)
 	n := newLeafNode(3)
 	key := newMockKey(3, 3)
@@ -19,15 +38,15 @@ func TestNodeInsert(t *testing.T) {
 	assert.Equal(t, 0, n.keys[0].Compare(key))
 }
 
-func TestDuplicateNodeInsert(t *testing.T) {
+func TestDuplicateLeafNodeInsert(t *testing.T) {
 	tree := newBTree(3)
 	n := newLeafNode(3)
 	k1 := newMockKey(3, 3)
 	k2 := newMockKey(3, 4)
 
-	n.insert(tree, k1)
-	n.insert(tree, k2)
-	n.insert(tree, k1)
+	assert.True(t, n.insert(tree, k1))
+	assert.True(t, n.insert(tree, k2))
+	assert.False(t, n.insert(tree, k1))
 
 	assert.Len(t, n.keys, 1)
 	assert.Nil(t, n.pointer)
@@ -40,6 +59,75 @@ func TestDuplicateNodeInsert(t *testing.T) {
 	assert.Equal(t, 0, n.keys[0].Compare(k2))
 }
 
-func TestMultipleNodeInsert(t *testing.T) {
+func TestMultipleLeafNodeInsert(t *testing.T) {
+	tree := newBTree(3)
+	n := newLeafNode(3)
 
+	k1 := newMockKey(3, 3)
+	k2 := newMockKey(4, 4)
+
+	assert.True(t, n.insert(tree, k1))
+	n.insert(tree, k2)
+
+	if !assert.Len(t, n.keys, 2) {
+		return
+	}
+	assert.Nil(t, n.pointer)
+	assert.Equal(t, k1, n.keys[0].(*payload).keys[0])
+	assert.Equal(t, k2, n.keys[1].(*payload).keys[0])
+}
+
+func TestLeafNodeSplitEvenNumber(t *testing.T) {
+	keys := constructMockPayloads(4)
+
+	node := &lnode{
+		keys: keys,
+	}
+
+	key, left, right := node.split()
+	assert.Equal(t, keys[2].(*payload).key(), key)
+	assert.Equal(t, left.(*lnode).keys, keys[:2])
+	assert.Equal(t, right.(*lnode).keys, keys[2:])
+	assert.Equal(t, left.(*lnode).pointer, right)
+}
+
+func TestLeafNodeSplitOddNumber(t *testing.T) {
+	keys := constructMockPayloads(3)
+
+	node := &lnode{
+		keys: keys,
+	}
+
+	key, left, right := node.split()
+	assert.Equal(t, keys[1].(*payload).key(), key)
+	assert.Equal(t, left.(*lnode).keys, keys[:1])
+	assert.Equal(t, right.(*lnode).keys, keys[1:])
+	assert.Equal(t, left.(*lnode).pointer, right)
+}
+
+func TestTwoKeysLeafNodeSplit(t *testing.T) {
+	keys := constructMockPayloads(2)
+
+	node := &lnode{
+		keys: keys,
+	}
+
+	key, left, right := node.split()
+	assert.Equal(t, keys[1].(*payload).key(), key)
+	assert.Equal(t, left.(*lnode).keys, keys[:1])
+	assert.Equal(t, right.(*lnode).keys, keys[1:])
+	assert.Equal(t, left.(*lnode).pointer, right)
+}
+
+func TestLessThanTwoKeysSplit(t *testing.T) {
+	keys := constructMockPayloads(1)
+
+	node := &lnode{
+		keys: keys,
+	}
+
+	key, left, right := node.split()
+	assert.Nil(t, key)
+	assert.Nil(t, left)
+	assert.Nil(t, right)
 }


### PR DESCRIPTION
I'm leaving this as an open CR for now.

This includes work required to create a B+ tree.  I have the leaf nodes splitting, need to add that to internal nodes.  I currently split the idea of internal/leaf using different structures with a common interface.  I'm worried we are going to get killed on that conversion as Go has proven to be a bit slow (doing type checking and what not) when calling a method on an interface.  I'm all ears if anyone has any better ideas :).  Doing this does save us from allocating unnecessary lists and pointers within a common struct.

I'm also using the builtin cap and len functions to mimic having a full array with nil pointers.  This means that the internal append logic and what not can handle some of that indexing for us, and if we're going to take the hit with 24-byte empty slice pointers might as well reuse it.

Currently, this is just inserts on leaf nodes.  Going to work on inserts for internal nodes and then deletes (which will be the hardest imo).  Once that is done I'll slap some query methods on this and we'll have a B+ tree to index cell values (if this will end up being memory efficient enough).

Forgot to mention, duplicate key handling.  Currently the items held in the leaf nodes are payload structs that have a slice of actual keys attached.  We order this list by the ID that every key is required to have.  In this way we can allow insertion of duplicate key values but not IDs.  We'll cover a lot of cases where cells have identical values in a reasonably fast way (would be faster without deletes :().  This would be especially helpful in VLookup sorts of situations as we can basically find a match in all cells in logarithmic time, create a bitmap of the hits, and intersect that bitmap with all cells in the interesting range.  That operation should be exceedingly fast.

@alexandercampbell-wf @beaulyddon-wf @tannermiller-wf