### PR TITLE
Overwriting rangetree entries

### DIFF
--- a/rangetree/immutable.go
+++ b/rangetree/immutable.go
@@ -51,7 +51,7 @@ func (irt *immutableRangeTree) add(nodes *orderedNodes, cache []slice.Int64Slice
 
 			newNode := newNode(entry.ValueAtDimension(i), entry, false)
 			overwritten := list.add(newNode)
-			if !overwritten {
+			if overwritten == nil {
 				*added++
 			}
 			if node != nil {

--- a/rangetree/immutable_test.go
+++ b/rangetree/immutable_test.go
@@ -52,15 +52,15 @@ func TestImmutableSingleDimensionMultipleAdds(t *testing.T) {
 
 	result := tree1.Query(iv)
 	assert.Equal(t, Entries{e1}, result)
-	assert.Equal(t, 1, tree1.Len())
+	assert.Equal(t, uint64(1), tree1.Len())
 
 	result = tree2.Query(iv)
 	assert.Equal(t, Entries{e1, e2}, result)
-	assert.Equal(t, 2, tree2.Len())
+	assert.Equal(t, uint64(2), tree2.Len())
 
 	result = tree3.Query(iv)
 	assert.Equal(t, Entries{e1, e2, e3}, result)
-	assert.Equal(t, 3, tree3.Len())
+	assert.Equal(t, uint64(3), tree3.Len())
 }
 
 func TestImmutableSingleDimensionBulkAdd(t *testing.T) {
@@ -75,7 +75,7 @@ func TestImmutableSingleDimensionBulkAdd(t *testing.T) {
 
 	result := tree1.Query(constructMockInterval(dimension{0, 10}, dimension{0, 10}))
 	assert.Equal(t, entries, result)
-	assert.Equal(t, 3, tree1.Len())
+	assert.Equal(t, uint64(3), tree1.Len())
 }
 
 func TestImmutableMultiDimensionAdd(t *testing.T) {
@@ -108,15 +108,15 @@ func TestImmutableMultiDimensionMultipleAdds(t *testing.T) {
 
 	result := tree1.Query(iv)
 	assert.Equal(t, Entries{e1}, result)
-	assert.Equal(t, 1, tree1.Len())
+	assert.Equal(t, uint64(1), tree1.Len())
 
 	result = tree2.Query(iv)
 	assert.Equal(t, Entries{e1, e2}, result)
-	assert.Equal(t, 2, tree2.Len())
+	assert.Equal(t, uint64(2), tree2.Len())
 
 	result = tree3.Query(iv)
 	assert.Equal(t, Entries{e1, e2, e3}, result)
-	assert.Equal(t, 3, tree3.Len())
+	assert.Equal(t, uint64(3), tree3.Len())
 }
 
 func TestImmutableMultiDimensionBulkAdd(t *testing.T) {
@@ -131,7 +131,7 @@ func TestImmutableMultiDimensionBulkAdd(t *testing.T) {
 
 	result := tree1.Query(constructMockInterval(dimension{0, 10}, dimension{0, 10}))
 	assert.Equal(t, entries, result)
-	assert.Equal(t, 3, tree1.Len())
+	assert.Equal(t, uint64(3), tree1.Len())
 }
 
 func BenchmarkImmutableMultiDimensionInserts(b *testing.B) {
@@ -214,21 +214,21 @@ func TestImmutableSingleDimensionMultipleDeletes(t *testing.T) {
 	tree4 := tree3.Delete(e3)
 	result := tree4.Query(iv)
 	assert.Equal(t, Entries{e1, e2}, result)
-	assert.Equal(t, 2, tree4.Len())
+	assert.Equal(t, uint64(2), tree4.Len())
 
 	tree5 := tree4.Delete(e2)
 	result = tree5.Query(iv)
 	assert.Equal(t, Entries{e1}, result)
-	assert.Equal(t, 1, tree5.Len())
+	assert.Equal(t, uint64(1), tree5.Len())
 
 	tree6 := tree5.Delete(e1)
 	result = tree6.Query(iv)
 	assert.Len(t, result, 0)
-	assert.Equal(t, 0, tree6.Len())
+	assert.Equal(t, uint64(0), tree6.Len())
 
 	result = tree3.Query(iv)
 	assert.Equal(t, Entries{e1, e2, e3}, result)
-	assert.Equal(t, 3, tree3.Len())
+	assert.Equal(t, uint64(3), tree3.Len())
 
 	tree7 := tree3.Delete(constructMockEntry(0, int64(3), int64(3)))
 	assert.Equal(t, tree3, tree7)
@@ -247,13 +247,13 @@ func TestImmutableSingleDimensionBulkDeletes(t *testing.T) {
 
 	result := tree2.Query(iv)
 	assert.Equal(t, Entries{e1}, result)
-	assert.Equal(t, 1, tree2.Len())
+	assert.Equal(t, uint64(1), tree2.Len())
 
 	tree3 := tree2.Delete(e1)
 
 	result = tree3.Query(iv)
 	assert.Len(t, result, 0)
-	assert.Equal(t, 0, tree3.Len())
+	assert.Equal(t, uint64(0), tree3.Len())
 }
 
 func TestImmutableMultiDimensionDelete(t *testing.T) {
@@ -266,7 +266,7 @@ func TestImmutableMultiDimensionDelete(t *testing.T) {
 
 	result := tree3.Query(iv)
 	assert.Len(t, result, 0)
-	assert.Equal(t, 0, tree3.Len())
+	assert.Equal(t, uint64(0), tree3.Len())
 }
 
 func TestImmutableMultiDimensionMultipleDeletes(t *testing.T) {
@@ -284,21 +284,21 @@ func TestImmutableMultiDimensionMultipleDeletes(t *testing.T) {
 
 	result := tree4.Query(iv)
 	assert.Equal(t, Entries{e1, e2}, result)
-	assert.Equal(t, 2, tree4.Len())
+	assert.Equal(t, uint64(2), tree4.Len())
 
 	tree5 := tree4.Delete(e2)
 	result = tree5.Query(iv)
 	assert.Equal(t, Entries{e1}, result)
-	assert.Equal(t, 1, tree5.Len())
+	assert.Equal(t, uint64(1), tree5.Len())
 
 	tree6 := tree5.Delete(e1)
 	result = tree6.Query(iv)
 	assert.Len(t, result, 0)
-	assert.Equal(t, 0, tree6.Len())
+	assert.Equal(t, uint64(0), tree6.Len())
 
 	result = tree3.Query(iv)
 	assert.Equal(t, Entries{e1, e2, e3}, result)
-	assert.Equal(t, 3, tree3.Len())
+	assert.Equal(t, uint64(3), tree3.Len())
 
 	tree7 := tree3.Delete(constructMockEntry(0, int64(3), int64(3)))
 	assert.Equal(t, tree3, tree7)
@@ -317,13 +317,13 @@ func TestImmutableMultiDimensionBulkDeletes(t *testing.T) {
 
 	result := tree2.Query(iv)
 	assert.Equal(t, Entries{e1}, result)
-	assert.Equal(t, 1, tree2.Len())
+	assert.Equal(t, uint64(1), tree2.Len())
 
 	tree3 := tree2.Delete(e1)
 
 	result = tree3.Query(iv)
 	assert.Len(t, result, 0)
-	assert.Equal(t, 0, tree3.Len())
+	assert.Equal(t, uint64(0), tree3.Len())
 }
 
 func constructMultiDimensionalImmutableTree(number int64) (*immutableRangeTree, Entries) {
@@ -422,11 +422,11 @@ func TestImmutableInsertNegativeIndexFirstDimension(t *testing.T) {
 
 	result = tree1.Query(constructMockInterval(dimension{2, 10}, dimension{1, 10}))
 	assert.Len(t, result, 0)
-	assert.Equal(t, 2, tree1.Len())
+	assert.Equal(t, uint64(2), tree1.Len())
 
 	result = tree.Query(constructMockInterval(dimension{2, 10}, dimension{1, 10}))
 	assert.Equal(t, entries[2:], result)
-	assert.Equal(t, 3, tree.Len())
+	assert.Equal(t, uint64(3), tree.Len())
 }
 
 func TestImmutableInsertNegativeIndexSecondDimension(t *testing.T) {
@@ -441,11 +441,11 @@ func TestImmutableInsertNegativeIndexSecondDimension(t *testing.T) {
 
 	result = tree1.Query(constructMockInterval(dimension{1, 10}, dimension{2, 10}))
 	assert.Len(t, result, 0)
-	assert.Equal(t, 2, tree1.Len())
+	assert.Equal(t, uint64(2), tree1.Len())
 
 	result = tree.Query(constructMockInterval(dimension{1, 10}, dimension{2, 10}))
 	assert.Equal(t, entries[2:], result)
-	assert.Equal(t, 3, tree.Len())
+	assert.Equal(t, uint64(3), tree.Len())
 }
 
 func TestImmutableInsertNegativeIndexOutOfBoundsFirstDimension(t *testing.T) {
@@ -475,7 +475,7 @@ func TestImmutableInsertMultipleNegativeIndexFirstDimension(t *testing.T) {
 
 	result := tree1.Query(constructMockInterval(dimension{1, 10}, dimension{1, 10}))
 	assert.Len(t, result, 0)
-	assert.Equal(t, 1, tree1.Len())
+	assert.Equal(t, uint64(1), tree1.Len())
 
 	result = tree.Query(constructMockInterval(dimension{1, 10}, dimension{1, 10}))
 	assert.Equal(t, entries[1:], result)
@@ -490,7 +490,7 @@ func TestImmutableInsertMultipleNegativeIndexSecondDimension(t *testing.T) {
 
 	result := tree1.Query(constructMockInterval(dimension{1, 10}, dimension{1, 10}))
 	assert.Len(t, result, 0)
-	assert.Equal(t, 1, tree1.Len())
+	assert.Equal(t, uint64(1), tree1.Len())
 
 	result = tree.Query(constructMockInterval(dimension{1, 10}, dimension{1, 10}))
 	assert.Equal(t, entries[1:], result)

--- a/rangetree/interface.go
+++ b/rangetree/interface.go
@@ -48,8 +48,10 @@ type Interval interface {
 
 // RangeTree describes the methods available to the rangetree.
 type RangeTree interface {
-	// Add will add the provided entries to the tree.
-	Add(entries ...Entry)
+	// Add will add the provided entries to the tree.  Any entries that
+	// were overwritten will be returned in the order in which they
+	// were overwritten.
+	Add(entries ...Entry) Entries
 	// Len returns the number of entries in the tree.
 	Len() uint64
 	// Delete will remove the provided entries from the tree.

--- a/rangetree/ordered.go
+++ b/rangetree/ordered.go
@@ -29,26 +29,29 @@ func (nodes orderedNodes) search(value int64) int {
 	)
 }
 
-func (nodes *orderedNodes) addAt(i int, node *node) bool {
+// addAt will add the provided node at the provided index.  Returns
+// a node if one was overwritten.
+func (nodes *orderedNodes) addAt(i int, node *node) *node {
 	if i == len(*nodes) {
 		*nodes = append(*nodes, node)
-		return false
+		return nil
 	}
 
 	if (*nodes)[i].value == node.value {
+		overwritten := (*nodes)[i]
 		// this is a duplicate, there can't be a duplicate
 		// point in the last dimension
 		(*nodes)[i] = node
-		return true
+		return overwritten
 	}
 
 	*nodes = append(*nodes, nil)
 	copy((*nodes)[i+1:], (*nodes)[i:])
 	(*nodes)[i] = node
-	return false
+	return nil
 }
 
-func (nodes *orderedNodes) add(node *node) bool {
+func (nodes *orderedNodes) add(node *node) *node {
 	i := nodes.search(node.value)
 	return nodes.addAt(i, node)
 }

--- a/rangetree/orderedtree.go
+++ b/rangetree/orderedtree.go
@@ -40,7 +40,9 @@ func (ot *orderedTree) needNextDimension() bool {
 	return ot.dimensions > 1
 }
 
-func (ot *orderedTree) add(entry Entry) {
+// add will add the provided entry to the rangetree and return an
+// entry if one was overwritten.
+func (ot *orderedTree) add(entry Entry) *node {
 	var node *node
 	list := &ot.top
 
@@ -49,25 +51,37 @@ func (ot *orderedTree) add(entry Entry) {
 			overwritten := list.add(
 				newNode(entry.ValueAtDimension(i), entry, false),
 			)
-			if !overwritten {
+			if overwritten == nil {
 				ot.number++
 			}
-			break
+			return overwritten
 		}
 		node, _ = list.getOrAdd(entry, i, ot.dimensions)
 		list = &node.orderedNodes
 	}
+
+	return nil
 }
 
 // Add will add the provided entries to the tree.
-func (ot *orderedTree) Add(entries ...Entry) {
+func (ot *orderedTree) Add(entries ...Entry) Entries {
+	if len(entries) == 0 {
+		return nil
+	}
+
+	overwrittens := make(Entries, 0, len(entries))
 	for _, entry := range entries {
 		if entry == nil {
 			continue
 		}
 
-		ot.add(entry)
+		overwritten := ot.add(entry)
+		if overwritten != nil {
+			overwrittens = append(overwrittens, overwritten.entry)
+		}
 	}
+
+	return overwrittens
 }
 
 func (ot *orderedTree) delete(entry Entry) {

--- a/rangetree/orderedtree_test.go
+++ b/rangetree/orderedtree_test.go
@@ -40,7 +40,7 @@ func constructMultiDimensionalOrderedTree(number uint64) (
 func TestOTRootAddMultipleDimensions(t *testing.T) {
 	tree, entries := constructMultiDimensionalOrderedTree(1)
 
-	assert.Equal(t, 1, tree.Len())
+	assert.Equal(t, uint64(1), tree.Len())
 
 	result := tree.Query(constructMockInterval(dimension{0, 1}, dimension{0, 1}))
 	assert.Equal(t, Entries{entries[0]}, result)
@@ -49,7 +49,7 @@ func TestOTRootAddMultipleDimensions(t *testing.T) {
 func TestOTMultipleAddMultipleDimensions(t *testing.T) {
 	tree, entries := constructMultiDimensionalOrderedTree(4)
 
-	assert.Equal(t, 4, tree.Len())
+	assert.Equal(t, uint64(4), tree.Len())
 
 	result := tree.Query(constructMockInterval(dimension{0, 1}, dimension{0, 1}))
 	assert.Equal(t, Entries{entries[0]}, result)
@@ -80,7 +80,7 @@ func TestOTAddInOrderMultiDimensions(t *testing.T) {
 	tree, entries := constructMultiDimensionalOrderedTree(10)
 
 	result := tree.Query(constructMockInterval(dimension{0, 10}, dimension{0, 10}))
-	assert.Equal(t, 10, tree.Len())
+	assert.Equal(t, uint64(10), tree.Len())
 	assert.Len(t, result, 10)
 	assert.Equal(t, entries, result)
 }
@@ -94,7 +94,7 @@ func TestOTAddReverseOrderMultiDimensions(t *testing.T) {
 
 	result := tree.Query(constructMockInterval(dimension{0, 11}, dimension{0, 11}))
 	assert.Len(t, result, 10)
-	assert.Equal(t, 10, tree.Len())
+	assert.Equal(t, uint64(10), tree.Len())
 }
 
 func TestOTAddRandomOrderMultiDimensions(t *testing.T) {
@@ -108,7 +108,7 @@ func TestOTAddRandomOrderMultiDimensions(t *testing.T) {
 
 	result := tree.Query(constructMockInterval(dimension{0, 5}, dimension{0, 5}))
 	assert.Len(t, result, 5)
-	assert.Equal(t, 5, tree.Len())
+	assert.Equal(t, uint64(5), tree.Len())
 }
 
 func TestOTAddLargeNumbersMultiDimension(t *testing.T) {
@@ -171,7 +171,7 @@ func TestOTRootDeleteMultiDimensions(t *testing.T) {
 	tree, entries := constructMultiDimensionalOrderedTree(1)
 	tree.Delete(entries...)
 
-	assert.Equal(t, 0, tree.Len())
+	assert.Equal(t, uint64(0), tree.Len())
 
 	result := tree.Query(constructMockInterval(dimension{0, 100}, dimension{0, 100}))
 	assert.Len(t, result, 0)
@@ -182,7 +182,7 @@ func TestOTDeleteMultiDimensions(t *testing.T) {
 
 	tree.Delete(entries[2])
 
-	assert.Equal(t, 3, tree.Len())
+	assert.Equal(t, uint64(3), tree.Len())
 
 	result := tree.Query(constructMockInterval(dimension{0, 4}, dimension{0, 4}))
 	assert.Equal(t, Entries{entries[0], entries[1], entries[3]}, result)
@@ -201,7 +201,7 @@ func TestOTDeleteInOrderMultiDimensions(t *testing.T) {
 
 	result := tree.Query(constructMockInterval(dimension{0, 10}, dimension{0, 10}))
 	assert.Len(t, result, 9)
-	assert.Equal(t, 9, tree.Len())
+	assert.Equal(t, uint64(9), tree.Len())
 
 	assert.NotContains(t, result, entries[5])
 }
@@ -220,7 +220,7 @@ func TestOTDeleteReverseOrderMultiDimensions(t *testing.T) {
 
 	result := tree.Query(constructMockInterval(dimension{0, 11}, dimension{0, 11}))
 	assert.Len(t, result, 9)
-	assert.Equal(t, 9, tree.Len())
+	assert.Equal(t, uint64(9), tree.Len())
 
 	assert.NotContains(t, result, entries[5])
 }
@@ -241,7 +241,7 @@ func TestOTDeleteRandomOrderMultiDimensions(t *testing.T) {
 	result := tree.Query(constructMockInterval(dimension{0, 11}, dimension{0, 11}))
 
 	assert.Len(t, result, 4)
-	assert.Equal(t, 4, tree.Len())
+	assert.Equal(t, uint64(4), tree.Len())
 
 	assert.NotContains(t, result, entries[2])
 }
@@ -251,7 +251,7 @@ func TestOTDeleteEmptyTreeMultiDimensions(t *testing.T) {
 
 	tree.Delete(constructMockEntry(0, 0, 0))
 
-	assert.Equal(t, 0, tree.Len())
+	assert.Equal(t, uint64(0), tree.Len())
 }
 
 func BenchmarkOTDeleteItemsMultiDimensions(b *testing.B) {
@@ -286,7 +286,12 @@ func TestOverwrites(t *testing.T) {
 	results := tree.Query(constructMockInterval(dimension{0, 100}, dimension{0, 100}))
 
 	assert.Equal(t, Entries{entry}, results)
-	assert.Equal(t, 1, tree.Len())
+	assert.Equal(t, uint64(1), tree.Len())
+
+	newEntry := constructMockEntry(0, 0, 0)
+
+	overwritten := tree.Add(newEntry)
+	assert.Equal(t, Entries{entry}, overwritten)
 }
 
 func TestTreeApply(t *testing.T) {
@@ -416,7 +421,7 @@ func TestInsertNegativeIndexFirstDimension(t *testing.T) {
 
 	result = tree.Query(constructMockInterval(dimension{2, 10}, dimension{1, 10}))
 	assert.Len(t, result, 0)
-	assert.Equal(t, 2, tree.Len())
+	assert.Equal(t, uint64(2), tree.Len())
 }
 
 func TestInsertNegativeIndexSecondDimension(t *testing.T) {
@@ -431,7 +436,7 @@ func TestInsertNegativeIndexSecondDimension(t *testing.T) {
 
 	result = tree.Query(constructMockInterval(dimension{1, 10}, dimension{2, 10}))
 	assert.Len(t, result, 0)
-	assert.Equal(t, 2, tree.Len())
+	assert.Equal(t, uint64(2), tree.Len())
 }
 
 func TestInsertNegativeIndexOutOfBoundsFirstDimension(t *testing.T) {
@@ -444,7 +449,7 @@ func TestInsertNegativeIndexOutOfBoundsFirstDimension(t *testing.T) {
 	result := tree.Query(constructMockInterval(dimension{0, 10}, dimension{0, 10}))
 
 	assert.Equal(t, entries, result)
-	assert.Equal(t, 3, tree.Len())
+	assert.Equal(t, uint64(3), tree.Len())
 }
 
 func TestInsertNegativeIndexOutOfBoundsSecondDimension(t *testing.T) {
@@ -457,7 +462,7 @@ func TestInsertNegativeIndexOutOfBoundsSecondDimension(t *testing.T) {
 	result := tree.Query(constructMockInterval(dimension{0, 10}, dimension{0, 10}))
 
 	assert.Equal(t, entries, result)
-	assert.Equal(t, 3, tree.Len())
+	assert.Equal(t, uint64(3), tree.Len())
 }
 
 func TestInsertMultipleNegativeIndexFirstDimension(t *testing.T) {
@@ -469,7 +474,7 @@ func TestInsertMultipleNegativeIndexFirstDimension(t *testing.T) {
 
 	result := tree.Query(constructMockInterval(dimension{1, 10}, dimension{1, 10}))
 	assert.Len(t, result, 0)
-	assert.Equal(t, 1, tree.Len())
+	assert.Equal(t, uint64(1), tree.Len())
 }
 
 func TestInsertMultipleNegativeIndexSecondDimension(t *testing.T) {
@@ -481,7 +486,7 @@ func TestInsertMultipleNegativeIndexSecondDimension(t *testing.T) {
 
 	result := tree.Query(constructMockInterval(dimension{1, 10}, dimension{1, 10}))
 	assert.Len(t, result, 0)
-	assert.Equal(t, 1, tree.Len())
+	assert.Equal(t, uint64(1), tree.Len())
 }
 
 func TestInsertInvalidDimension(t *testing.T) {


### PR DESCRIPTION
CODE REVIEW

Overwriting nodes in the rangetree now returns those nodes so the consumer doesn't have to pre-check to see if entries have been overwritten manually.

This should speed up adding items to the rangetree as we currently check before write to see if a node is about to be overwritten.

TODO: add this capability to the immutable version of the tree when I unify them under one interface.

@tannermiller-wf @beaulyddon-wf @rosshendrickson-wf @alexandercampbell-wf @tylertreat-wf @stevenosborne-wf @ericolson-wf 
