### PR TITLE
Integer hashmap

### DIFF
--- a/hashmap/fastinteger/hash.go
+++ b/hashmap/fastinteger/hash.go
@@ -1,0 +1,13 @@
+package fastinteger
+
+// hash will convert the uint64 key into a hash based on Murmur3's 64-bit
+// integer finalizer.
+// Details here: https://code.google.com/p/smhasher/wiki/MurmurHash3
+func hash(key uint64) uint64 {
+	key ^= key >> 33
+	key *= 0xff51afd7ed558ccd
+	key ^= key >> 33
+	key *= 0xc4ceb9fe1a85ec53
+	key ^= key >> 33
+	return key
+}

--- a/hashmap/fastinteger/hash_test.go
+++ b/hashmap/fastinteger/hash_test.go
@@ -1,0 +1,56 @@
+package fastinteger
+
+import (
+	"encoding/binary"
+	"hash/fnv"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHash(t *testing.T) {
+	key := uint64(5)
+	h := hash(key)
+
+	assert.NotEqual(t, key, h)
+}
+
+func BenchmarkHash(b *testing.B) {
+	numItems := 1000
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	keys := make([]uint64, 0, numItems)
+	for i := 0; i < numItems; i++ {
+		key := uint64(r.Int63())
+		keys = append(keys, key)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, key := range keys {
+			hash(key)
+		}
+	}
+}
+
+func BenchmarkFnvHash(b *testing.B) {
+	numItems := 1000
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	keys := make([]uint64, 0, numItems)
+	for i := 0; i < numItems; i++ {
+		key := uint64(r.Int63())
+		keys = append(keys, key)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, key := range keys {
+			hasher := fnv.New64()
+			binary.Write(hasher, binary.LittleEndian, key)
+			hasher.Sum64()
+		}
+	}
+}

--- a/hashmap/fastinteger/hashmap.go
+++ b/hashmap/fastinteger/hashmap.go
@@ -1,0 +1,104 @@
+package fastinteger
+
+const ratio = .75 // ratio sets the capacity the hashmap has to be at before it expands
+
+type packet struct {
+	key   uint64
+	value interface{}
+}
+
+type packets []*packet
+
+func (packets packets) find(key uint64) uint64 {
+	h := hash(key)
+	i := h % uint64(len(packets))
+	for packets[i] != nil && packets[i].key != key {
+		i = (i + 1) % uint64(len(packets))
+	}
+
+	return i
+}
+
+func (packets packets) set(packet *packet) {
+	i := packets.find(packet.key)
+	if packets[i] == nil {
+		packets[i] = packet
+		return
+	}
+
+	packets[i].value = packet.value
+}
+
+func (packets packets) get(key uint64) interface{} {
+	i := packets.find(key)
+	if packets[i] == nil {
+		return nil
+	}
+
+	return packets[i].value
+}
+
+func (packets packets) exists(key uint64) bool {
+	i := packets.find(key)
+	return packets[i] != nil // technically, they can store nil
+}
+
+// FastIntegerHashMap is a simple hashmap to be used with
+// integer only keys.  It supports few operations, and is designed
+// primarily for cases where the consumer needs a very simple
+// datastructure to set and check for existence of integer
+// keys over a sparse range.
+type FastIntegerHashMap struct {
+	count   uint64
+	packets packets
+}
+
+// rebuild is an expensive operation which requires us to iterate
+// over the current bucket and rehash the keys for insertion into
+// the new bucket.  The new bucket is twice as large as the old
+// bucket by default.
+func (fi *FastIntegerHashMap) rebuild() {
+	packets := make(packets, len(fi.packets)*2)
+	for _, packet := range fi.packets {
+		if packet == nil {
+			continue
+		}
+
+		packets.set(packet)
+	}
+	fi.packets = packets
+}
+
+// Get returns an item from the map if it exists.  Otherwise,
+// returns nil.
+func (fi *FastIntegerHashMap) Get(key uint64) interface{} {
+	return fi.packets.get(key)
+}
+
+// Set will set the provided key with the provided value.
+func (fi *FastIntegerHashMap) Set(key uint64, value interface{}) {
+	if float64(fi.count+1)/float64(len(fi.packets)) > ratio {
+		fi.rebuild()
+	}
+
+	fi.packets.set(&packet{key: key, value: value})
+	fi.count++
+}
+
+// Exists will return a bool indicating if the provided key
+// exists in the map.
+func (fi *FastIntegerHashMap) Exists(key uint64) bool {
+	return fi.packets.exists(key)
+}
+
+// New returns a new FastIntegerHashMap with a bucket size specified
+// by hint.
+func New(hint uint64) *FastIntegerHashMap {
+	if hint == 0 {
+		hint = 10
+	}
+	return &FastIntegerHashMap{
+		count:   0,
+		packets: make(packets, hint),
+	}
+}

--- a/hashmap/fastinteger/hashmap_test.go
+++ b/hashmap/fastinteger/hashmap_test.go
@@ -1,0 +1,50 @@
+package fastinteger
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInsert(t *testing.T) {
+	hm := New(10)
+
+	hm.Set(5, 5)
+
+	assert.True(t, hm.Exists(5))
+	assert.Equal(t, 5, hm.Get(5))
+}
+
+func TestInsertOverwrite(t *testing.T) {
+	hm := New(10)
+
+	hm.Set(5, 5)
+	hm.Set(5, 10)
+
+	assert.True(t, hm.Exists(5))
+	assert.Equal(t, 10, hm.Get(5))
+}
+
+func TestMultipleInserts(t *testing.T) {
+	hm := New(10)
+
+	hm.Set(5, 5)
+	hm.Set(6, 6)
+
+	assert.True(t, hm.Exists(6))
+	assert.Equal(t, 6, hm.Get(6))
+}
+
+func TestRebuild(t *testing.T) {
+	numItems := uint64(100)
+
+	hm := New(10)
+
+	for i := uint64(0); i < numItems; i++ {
+		hm.Set(i, i)
+	}
+
+	for i := uint64(0); i < numItems; i++ {
+		assert.Equal(t, i, hm.Get(i))
+	}
+}

--- a/hashmap/fastinteger/hashmap_test.go
+++ b/hashmap/fastinteger/hashmap_test.go
@@ -1,10 +1,35 @@
 package fastinteger
 
 import (
+	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func generateKeys(num int) []uint64 {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	keys := make([]uint64, 0, num)
+	for i := 0; i < num; i++ {
+		key := uint64(r.Int63())
+		keys = append(keys, key)
+	}
+
+	return keys
+}
+
+func TestRoundUp(t *testing.T) {
+	result := roundUp(21)
+	assert.Equal(t, uint64(32), result)
+
+	result = roundUp(uint64(1<<31) - 234)
+	assert.Equal(t, uint64(1<<31), result)
+
+	result = roundUp(uint64(1<<63) - 324)
+	assert.Equal(t, uint64(1<<63), result)
+}
 
 func TestInsert(t *testing.T) {
 	hm := New(10)
@@ -12,7 +37,9 @@ func TestInsert(t *testing.T) {
 	hm.Set(5, 5)
 
 	assert.True(t, hm.Exists(5))
-	assert.Equal(t, 5, hm.Get(5))
+	value, ok := hm.Get(5)
+	assert.Equal(t, uint64(5), value)
+	assert.True(t, ok)
 }
 
 func TestInsertOverwrite(t *testing.T) {
@@ -22,7 +49,17 @@ func TestInsertOverwrite(t *testing.T) {
 	hm.Set(5, 10)
 
 	assert.True(t, hm.Exists(5))
-	assert.Equal(t, 10, hm.Get(5))
+	value, ok := hm.Get(5)
+	assert.Equal(t, uint64(10), value)
+	assert.True(t, ok)
+}
+
+func TestGet(t *testing.T) {
+	hm := New(10)
+
+	value, ok := hm.Get(5)
+	assert.False(t, ok)
+	assert.Equal(t, uint64(0), value)
 }
 
 func TestMultipleInserts(t *testing.T) {
@@ -32,7 +69,9 @@ func TestMultipleInserts(t *testing.T) {
 	hm.Set(6, 6)
 
 	assert.True(t, hm.Exists(6))
-	assert.Equal(t, 6, hm.Get(6))
+	value, ok := hm.Get(6)
+	assert.True(t, ok)
+	assert.Equal(t, uint64(6), value)
 }
 
 func TestRebuild(t *testing.T) {
@@ -45,6 +84,77 @@ func TestRebuild(t *testing.T) {
 	}
 
 	for i := uint64(0); i < numItems; i++ {
-		assert.Equal(t, i, hm.Get(i))
+		value, _ := hm.Get(i)
+		assert.Equal(t, i, value)
 	}
+}
+
+func BenchmarkInsert(b *testing.B) {
+	numItems := uint64(1000)
+
+	keys := generateKeys(int(numItems))
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		hm := New(numItems * 2) // so we don't rebuild
+		for _, k := range keys {
+			hm.Set(k, k)
+		}
+	}
+}
+
+func BenchmarkGoMapInsert(b *testing.B) {
+	numItems := uint64(1000)
+
+	keys := generateKeys(int(numItems))
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		hm := make(map[uint64]uint64, numItems*2) // so we don't rebuild
+		for _, k := range keys {
+			hm[k] = k
+		}
+	}
+}
+
+func BenchmarkExists(b *testing.B) {
+	numItems := uint64(1000)
+
+	keys := generateKeys(int(numItems))
+	hm := New(numItems * 2) // so we don't rebuild
+	for _, key := range keys {
+		hm.Set(key, key)
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		for _, key := range keys {
+			hm.Exists(key)
+		}
+	}
+}
+
+func BenchmarkGoMapExists(b *testing.B) {
+	numItems := uint64(1000)
+
+	keys := generateKeys(int(numItems))
+	hm := make(map[uint64]uint64, numItems*2) // so we don't rebuild
+	for _, key := range keys {
+		hm[key] = key
+	}
+
+	b.ResetTimer()
+
+	var ok bool
+	for i := 0; i < b.N; i++ {
+		for _, key := range keys {
+			_, ok = hm[key] // or the compiler complains
+		}
+	}
+
+	b.StopTimer()
+	b.Logf(`OK: %+v`, ok)
 }


### PR DESCRIPTION
CODE REVIEW

I needed a hashmap that is really fast for handling certain data types, namely uint64s (as all cells have that as a unique id).  These are often sparse so a dense bitmap doesn't always make sense and a sparse bitmap has log n operations.  This implementation of a bitmap has some constraints, namely the keys and values must be uint64, but it serves a purpose (and a uint64 can hold a uintptr if you are brave enough to use the unsafe package).

There are some somewhat funky things done to ensure speed better than Go's native implementation (benchmarked against map[uint64]uint64).  I think I could get better performance if I didn't use linear probing as my open addressing scheme, something I will toy with.

@beaulyddon-wf @tannermiller-wf @rosshendrickson-wf @alexandercampbell-wf @ericolson-wf @tylertreat-wf @stevenosborne-wf 