### PR TITLE
Y fast trie

### DIFF
--- a/trie/yfast/entries.go
+++ b/trie/yfast/entries.go
@@ -1,0 +1,130 @@
+package yfast
+
+import "sort"
+
+// entries is a typed list of Entry.  The size of entries
+// will be limited to 1/2log M to 2log M where M is the size
+// of the universe.
+type entries []Entry
+
+// search will perform a sort package search on this list
+// of entries and return an index indicating position.
+// If the returned index is >= len(entries) then a suitable
+// position could not be found.  The index does not guarantee
+// equality, just indicates where the key would be inserted.
+func (entries entries) search(key uint64) int {
+	return sort.Search(len(entries), func(i int) bool {
+		return entries[i].Key() >= key
+	})
+}
+
+// insert will insert the provided entry into this list of
+// entries.  Returned is an entry if an entry already exists
+// for the provided key.  If nothing is overwritten, Entry
+// will be nil.
+func (entries *entries) insert(entry Entry) Entry {
+	i := entries.search(entry.Key())
+
+	if i == len(*entries) {
+		*entries = append(*entries, entry)
+		return nil
+	}
+
+	if (*entries)[i].Key() == entry.Key() {
+		oldEntry := (*entries)[i]
+		(*entries)[i] = entry
+		return oldEntry
+	}
+
+	(*entries) = append(*entries, nil)
+	copy((*entries)[i+1:], (*entries)[i:])
+	(*entries)[i] = entry
+	return nil
+}
+
+// delete will remove the provided key from this list of entries.
+// Returned is a deleted Entry.  This will be nil if the key
+// cannot be found.
+func (entries *entries) delete(key uint64) Entry {
+	i := entries.search(key)
+	if i == len(*entries) { // key not found
+		return nil
+	}
+
+	if (*entries)[i].Key() != key {
+		return nil
+	}
+
+	oldEntry := (*entries)[i]
+	copy((*entries)[i:], (*entries)[i+1:])
+	(*entries)[len(*entries)-1] = nil // GC
+	*entries = (*entries)[:len(*entries)-1]
+	return oldEntry
+}
+
+// max returns the value of the highest key in this list
+// of entries.  The bool indicates if it's a valid key, that
+// is if there is more than zero entries in this list.
+func (entries entries) max() (uint64, bool) {
+	if len(entries) == 0 {
+		return 0, false
+	}
+
+	return entries[len(entries)-1].Key(), true
+}
+
+// get will perform a lookup over this list of entries
+// and return an Entry if it exists.  Returns nil if the
+// entry does not exist.
+func (entries entries) get(key uint64) Entry {
+	i := entries.search(key)
+	if i == len(entries) {
+		return nil
+	}
+
+	if entries[i].Key() == key {
+		return entries[i]
+	}
+
+	return nil
+}
+
+// successor will return the first entry that has a key
+// greater than or equal to provided key.  Also returned
+// is the index of the find.  Returns nil, -1 if a successor does
+// not exist.
+func (entries entries) successor(key uint64) (Entry, int) {
+	i := entries.search(key)
+	if i == len(entries) {
+		return nil, -1
+	}
+
+	return entries[i], i
+}
+
+// predecessor will return the first entry that has a key
+// less than or equal to the provided key.  Also returned
+// is the index of the find.  Returns nil, -1 if a predecessor
+// does not exist.
+func (entries entries) predecessor(key uint64) (Entry, int) {
+	if len(entries) == 0 {
+		return nil, -1
+	}
+
+	i := entries.search(key)
+	if i == len(entries) {
+		return entries[i-1], i - 1
+	}
+
+	if entries[i].Key() == key {
+		return entries[i], i
+	}
+
+	i--
+
+	if i < 0 {
+		return nil, -1
+	}
+
+	return entries[i], i
+}

--- a/trie/yfast/entries.go
+++ b/trie/yfast/entries.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2014 Workiva, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package yfast
 
 import "sort"

--- a/trie/yfast/entries.go
+++ b/trie/yfast/entries.go
@@ -2,17 +2,29 @@ package yfast
 
 import "sort"
 
-// entries is a typed list of Entry.  The size of entries
+type entriesWrapper struct {
+	key     uint64
+	entries Entries
+}
+
+// Key will return the key of the highest entry in this list.
+// This is required by the x-fast trie Entry interface.  This
+// returns 0 if this list is empty.
+func (ew *entriesWrapper) Key() uint64 {
+	return ew.key
+}
+
+// Entries is a typed list of Entry.  The size of entries
 // will be limited to 1/2log M to 2log M where M is the size
 // of the universe.
-type entries []Entry
+type Entries []Entry
 
 // search will perform a sort package search on this list
 // of entries and return an index indicating position.
 // If the returned index is >= len(entries) then a suitable
 // position could not be found.  The index does not guarantee
 // equality, just indicates where the key would be inserted.
-func (entries entries) search(key uint64) int {
+func (entries Entries) search(key uint64) int {
 	return sort.Search(len(entries), func(i int) bool {
 		return entries[i].Key() >= key
 	})
@@ -22,7 +34,7 @@ func (entries entries) search(key uint64) int {
 // entries.  Returned is an entry if an entry already exists
 // for the provided key.  If nothing is overwritten, Entry
 // will be nil.
-func (entries *entries) insert(entry Entry) Entry {
+func (entries *Entries) insert(entry Entry) Entry {
 	i := entries.search(entry.Key())
 
 	if i == len(*entries) {
@@ -45,7 +57,7 @@ func (entries *entries) insert(entry Entry) Entry {
 // delete will remove the provided key from this list of entries.
 // Returned is a deleted Entry.  This will be nil if the key
 // cannot be found.
-func (entries *entries) delete(key uint64) Entry {
+func (entries *Entries) delete(key uint64) Entry {
 	i := entries.search(key)
 	if i == len(*entries) { // key not found
 		return nil
@@ -65,7 +77,7 @@ func (entries *entries) delete(key uint64) Entry {
 // max returns the value of the highest key in this list
 // of entries.  The bool indicates if it's a valid key, that
 // is if there is more than zero entries in this list.
-func (entries entries) max() (uint64, bool) {
+func (entries Entries) max() (uint64, bool) {
 	if len(entries) == 0 {
 		return 0, false
 	}
@@ -76,7 +88,7 @@ func (entries entries) max() (uint64, bool) {
 // get will perform a lookup over this list of entries
 // and return an Entry if it exists.  Returns nil if the
 // entry does not exist.
-func (entries entries) get(key uint64) Entry {
+func (entries Entries) get(key uint64) Entry {
 	i := entries.search(key)
 	if i == len(entries) {
 		return nil
@@ -93,7 +105,7 @@ func (entries entries) get(key uint64) Entry {
 // greater than or equal to provided key.  Also returned
 // is the index of the find.  Returns nil, -1 if a successor does
 // not exist.
-func (entries entries) successor(key uint64) (Entry, int) {
+func (entries Entries) successor(key uint64) (Entry, int) {
 	i := entries.search(key)
 	if i == len(entries) {
 		return nil, -1
@@ -106,7 +118,7 @@ func (entries entries) successor(key uint64) (Entry, int) {
 // less than or equal to the provided key.  Also returned
 // is the index of the find.  Returns nil, -1 if a predecessor
 // does not exist.
-func (entries entries) predecessor(key uint64) (Entry, int) {
+func (entries Entries) predecessor(key uint64) (Entry, int) {
 	if len(entries) == 0 {
 		return nil, -1
 	}

--- a/trie/yfast/entries_test.go
+++ b/trie/yfast/entries_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestEntriesInsert(t *testing.T) {
-	es := entries{}
+	es := Entries{}
 
 	e1 := newMockEntry(5)
 	e2 := newMockEntry(1)
@@ -15,16 +15,16 @@ func TestEntriesInsert(t *testing.T) {
 	es.insert(e1)
 	es.insert(e2)
 
-	assert.Equal(t, entries{e2, e1}, es)
+	assert.Equal(t, Entries{e2, e1}, es)
 
 	e3 := newMockEntry(3)
 	es.insert(e3)
 
-	assert.Equal(t, entries{e2, e3, e1}, es)
+	assert.Equal(t, Entries{e2, e3, e1}, es)
 }
 
 func TestEntriesDelete(t *testing.T) {
-	es := entries{}
+	es := Entries{}
 
 	e1 := newMockEntry(5)
 	e2 := newMockEntry(1)
@@ -32,14 +32,14 @@ func TestEntriesDelete(t *testing.T) {
 	es.insert(e2)
 
 	es.delete(5)
-	assert.Equal(t, entries{e2}, es)
+	assert.Equal(t, Entries{e2}, es)
 
 	es.delete(1)
-	assert.Equal(t, entries{}, es)
+	assert.Equal(t, Entries{}, es)
 }
 
 func TestEntriesMax(t *testing.T) {
-	es := entries{}
+	es := Entries{}
 	max, ok := es.max()
 	assert.Equal(t, uint64(0), max)
 	assert.False(t, ok)
@@ -58,7 +58,7 @@ func TestEntriesMax(t *testing.T) {
 }
 
 func TestEntriesGet(t *testing.T) {
-	es := entries{}
+	es := Entries{}
 
 	e1 := newMockEntry(5)
 	e2 := newMockEntry(1)
@@ -76,7 +76,7 @@ func TestEntriesGet(t *testing.T) {
 }
 
 func TestEntriesSuccessor(t *testing.T) {
-	es := entries{}
+	es := Entries{}
 
 	successor, i := es.successor(5)
 	assert.Equal(t, -1, i)
@@ -105,7 +105,7 @@ func TestEntriesSuccessor(t *testing.T) {
 }
 
 func TestEntriesPredecessor(t *testing.T) {
-	es := entries{}
+	es := Entries{}
 
 	predecessor, i := es.predecessor(5)
 	assert.Equal(t, -1, i)

--- a/trie/yfast/entries_test.go
+++ b/trie/yfast/entries_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2014 Workiva, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package yfast
 
 import (

--- a/trie/yfast/entries_test.go
+++ b/trie/yfast/entries_test.go
@@ -1,0 +1,134 @@
+package yfast
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEntriesInsert(t *testing.T) {
+	es := entries{}
+
+	e1 := newMockEntry(5)
+	e2 := newMockEntry(1)
+
+	es.insert(e1)
+	es.insert(e2)
+
+	assert.Equal(t, entries{e2, e1}, es)
+
+	e3 := newMockEntry(3)
+	es.insert(e3)
+
+	assert.Equal(t, entries{e2, e3, e1}, es)
+}
+
+func TestEntriesDelete(t *testing.T) {
+	es := entries{}
+
+	e1 := newMockEntry(5)
+	e2 := newMockEntry(1)
+	es.insert(e1)
+	es.insert(e2)
+
+	es.delete(5)
+	assert.Equal(t, entries{e2}, es)
+
+	es.delete(1)
+	assert.Equal(t, entries{}, es)
+}
+
+func TestEntriesMax(t *testing.T) {
+	es := entries{}
+	max, ok := es.max()
+	assert.Equal(t, uint64(0), max)
+	assert.False(t, ok)
+
+	e2 := newMockEntry(1)
+	es.insert(e2)
+	max, ok = es.max()
+	assert.Equal(t, uint64(1), max)
+	assert.True(t, ok)
+
+	e1 := newMockEntry(5)
+	es.insert(e1)
+	max, ok = es.max()
+	assert.Equal(t, uint64(5), max)
+	assert.True(t, ok)
+}
+
+func TestEntriesGet(t *testing.T) {
+	es := entries{}
+
+	e1 := newMockEntry(5)
+	e2 := newMockEntry(1)
+	es.insert(e1)
+	es.insert(e2)
+
+	result := es.get(5)
+	assert.Equal(t, e1, result)
+
+	result = es.get(1)
+	assert.Equal(t, e2, result)
+
+	result = es.get(10)
+	assert.Nil(t, result)
+}
+
+func TestEntriesSuccessor(t *testing.T) {
+	es := entries{}
+
+	successor, i := es.successor(5)
+	assert.Equal(t, -1, i)
+	assert.Nil(t, successor)
+
+	e1 := newMockEntry(5)
+	e2 := newMockEntry(1)
+	es.insert(e1)
+	es.insert(e2)
+
+	successor, i = es.successor(0)
+	assert.Equal(t, 0, i)
+	assert.Equal(t, e2, successor)
+
+	successor, i = es.successor(2)
+	assert.Equal(t, 1, i)
+	assert.Equal(t, e1, successor)
+
+	successor, i = es.successor(5)
+	assert.Equal(t, 1, i)
+	assert.Equal(t, e1, successor)
+
+	successor, i = es.successor(10)
+	assert.Equal(t, -1, i)
+	assert.Nil(t, successor)
+}
+
+func TestEntriesPredecessor(t *testing.T) {
+	es := entries{}
+
+	predecessor, i := es.predecessor(5)
+	assert.Equal(t, -1, i)
+	assert.Nil(t, predecessor)
+
+	e1 := newMockEntry(5)
+	e2 := newMockEntry(1)
+	es.insert(e1)
+	es.insert(e2)
+
+	predecessor, i = es.predecessor(0)
+	assert.Equal(t, -1, i)
+	assert.Nil(t, predecessor)
+
+	predecessor, i = es.predecessor(2)
+	assert.Equal(t, 0, i)
+	assert.Equal(t, e2, predecessor)
+
+	predecessor, i = es.predecessor(5)
+	assert.Equal(t, 1, i)
+	assert.Equal(t, e1, predecessor)
+
+	predecessor, i = es.predecessor(10)
+	assert.Equal(t, 1, i)
+	assert.Equal(t, e1, predecessor)
+}

--- a/trie/yfast/interface.go
+++ b/trie/yfast/interface.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2014 Workiva, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package yfast
 
 // Entry defines items that can be inserted into the y-fast

--- a/trie/yfast/interface.go
+++ b/trie/yfast/interface.go
@@ -1,0 +1,11 @@
+package yfast
+
+// Entry defines items that can be inserted into the y-fast
+// trie.
+type Entry interface {
+	// Key is the key for this entry.  If the trie has been
+	// given bit size n, only the last n bits of this key
+	// will matter.  Use a bit size of 64 to enable all
+	// 2^64-1 keys.
+	Key() uint64
+}

--- a/trie/yfast/iterator.go
+++ b/trie/yfast/iterator.go
@@ -1,0 +1,78 @@
+package yfast
+
+import "github.com/Workiva/go-datastructures/trie/xfast"
+
+const iteratorExhausted = -2
+
+func iterExhausted(iter *Iterator) bool {
+	return iter.index == iteratorExhausted
+}
+
+type iterator interface {
+	Next() bool
+	Value() xfast.Entry
+}
+
+// Iterator will iterate of the results of a query.
+type Iterator struct {
+	xfastIterator iterator
+	index         int
+	entries       *entriesWrapper
+}
+
+// Next will return a bool indicating if another value exists
+// in the iterator.
+func (iter *Iterator) Next() bool {
+	if iterExhausted(iter) {
+		return false
+	}
+	iter.index++
+	if iter.index >= len(iter.entries.entries) {
+		next := iter.xfastIterator.Next()
+		if !next {
+			iter.index = iteratorExhausted
+			return false
+		}
+		var ok bool
+		iter.entries, ok = iter.xfastIterator.Value().(*entriesWrapper)
+		if !ok {
+			iter.index = iteratorExhausted
+			return false
+		}
+		iter.index = 0
+	}
+
+	return true
+}
+
+// Value will return the Entry representing the iterator's current position.
+// If no Entry exists at the present condition, the iterator is
+// exhausted and this method will return nil.
+func (iter *Iterator) Value() Entry {
+	if iterExhausted(iter) {
+		return nil
+	}
+
+	if iter.entries == nil || iter.index < 0 || iter.index >= len(iter.entries.entries) {
+		return nil
+	}
+
+	return iter.entries.entries[iter.index]
+}
+
+// exhaust is a helper function that will exhaust this iterator
+// and return a list of entries.  This is for internal use only.
+func (iter *Iterator) exhaust() Entries {
+	entries := make(Entries, 0, 100)
+	for it := iter; it.Next(); {
+		entries = append(entries, it.Value())
+	}
+
+	return entries
+}
+
+func nilIterator() *Iterator {
+	return &Iterator{
+		index: iteratorExhausted,
+	}
+}

--- a/trie/yfast/iterator.go
+++ b/trie/yfast/iterator.go
@@ -1,21 +1,36 @@
+/*
+Copyright 2014 Workiva, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package yfast
 
 import "github.com/Workiva/go-datastructures/trie/xfast"
 
+// iteratorExhausted is a magic value for an index to tell us
+// that the iterator has been exhausted.
 const iteratorExhausted = -2
 
+// iterExhausted is a helper function to tell us if an iterator
+// has been exhausted.
 func iterExhausted(iter *Iterator) bool {
 	return iter.index == iteratorExhausted
 }
 
-type iterator interface {
-	Next() bool
-	Value() xfast.Entry
-}
-
 // Iterator will iterate of the results of a query.
 type Iterator struct {
-	xfastIterator iterator
+	xfastIterator *xfast.Iterator
 	index         int
 	entries       *entriesWrapper
 }
@@ -71,6 +86,8 @@ func (iter *Iterator) exhaust() Entries {
 	return entries
 }
 
+// nilIterator is an iterator that will always return false
+// from Next() and nil for Value().
 func nilIterator() *Iterator {
 	return &Iterator{
 		index: iteratorExhausted,

--- a/trie/yfast/mock_test.go
+++ b/trie/yfast/mock_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2014 Workiva, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package yfast
 
 type mockEntry struct {

--- a/trie/yfast/mock_test.go
+++ b/trie/yfast/mock_test.go
@@ -1,0 +1,14 @@
+package yfast
+
+type mockEntry struct {
+	// not going to use mock here as it skews benchmarks
+	key uint64
+}
+
+func (me *mockEntry) Key() uint64 {
+	return me.key
+}
+
+func newMockEntry(key uint64) *mockEntry {
+	return &mockEntry{key}
+}

--- a/trie/yfast/yfast.go
+++ b/trie/yfast/yfast.go
@@ -1,0 +1,19 @@
+/*
+Package yfast implements a y-fast trie.  Instead of a red-black BBST
+for the leaves, this implementation uses a simple ordered list.  This
+package should have searches that are as performant as the x-fast
+trie while having faster inserts/deletes and linear space consumption.
+
+Performance characteristics:
+Space: O(n)
+Get: O(log log M)
+Search: O(log log M)
+Insert: O(log log M)
+Delete: O(log log M)
+
+where n is the number of items in the trie and M is the size of the
+universe, ie, 2^m where m is the number of bits in the specified key
+size.
+*/
+
+package yfast

--- a/trie/yfast/yfast.go
+++ b/trie/yfast/yfast.go
@@ -17,3 +17,254 @@ size.
 */
 
 package yfast
+
+import (
+	"log"
+
+	"github.com/Workiva/go-datastructures/trie/xfast"
+)
+
+func init() {
+	log.Println(`I HATE THIS`)
+}
+
+// YFastTrie implements all the methods available to the y-fast
+// trie datastructure.  The top half is composed of an x-fast trie
+// while the leaves are composed of ordered lists of type Entry,
+// an interface found in this package.
+type YFastTrie struct {
+	num   uint64
+	xfast *xfast.XFastTrie
+	bits  uint8
+}
+
+func (yfast *YFastTrie) init(intType interface{}) {
+	switch intType.(type) {
+	case uint8:
+		yfast.bits = 8
+	case uint16:
+		yfast.bits = 16
+	case uint32:
+		yfast.bits = 32
+	case uint, uint64:
+		yfast.bits = 64
+	default:
+		// we'll panic with a bad value to the constructor.
+		panic(`Invalid universe size provided.`)
+	}
+
+	yfast.xfast = xfast.New(intType)
+}
+
+func (yfast *YFastTrie) getBucketKey(key uint64) uint64 {
+	i := key/uint64(yfast.bits) + 1
+	return uint64(yfast.bits)*i - 1
+}
+
+func (yfast *YFastTrie) insert(entry Entry) Entry {
+	// first, we need to determine if we have a node in the x-trie
+	// that already matches for the key
+	bundleKey := yfast.getBucketKey(entry.Key())
+	bundle := yfast.xfast.Get(bundleKey)
+
+	if bundle != nil {
+		overwritten := bundle.(*entriesWrapper).entries.insert(entry)
+		if overwritten == nil {
+			yfast.num++
+			return nil
+		}
+
+		return overwritten
+	}
+
+	yfast.num++
+	entries := make(Entries, 0, yfast.bits)
+	entries.insert(entry)
+
+	ew := &entriesWrapper{
+		key:     bundleKey,
+		entries: entries,
+	}
+
+	yfast.xfast.Insert(ew)
+	return nil
+}
+
+// Insert will insert the provided entries into the y-fast trie
+// and return a list of entries that were overwritten.
+func (yfast *YFastTrie) Insert(entries ...Entry) Entries {
+	overwritten := make(Entries, 0, len(entries))
+	for _, e := range entries {
+		overwritten = append(overwritten, yfast.insert(e))
+	}
+
+	return overwritten
+}
+
+func (yfast *YFastTrie) delete(key uint64) Entry {
+	bundleKey := yfast.getBucketKey(key)
+
+	bundle := yfast.xfast.Get(bundleKey)
+	if bundle == nil {
+		return nil
+	}
+
+	ew := bundle.(*entriesWrapper)
+	entry := ew.entries.delete(key)
+	if entry == nil {
+		return nil
+	}
+
+	yfast.num--
+
+	if len(ew.entries) == 0 {
+		yfast.xfast.Delete(bundleKey)
+	}
+
+	return entry
+}
+
+// Delete will delete the provided keys from the y-fast trie
+// and return a list of entries that were deleted.
+func (yfast *YFastTrie) Delete(keys ...uint64) Entries {
+	entries := make(Entries, 0, len(keys))
+	for _, key := range keys {
+		entries = append(entries, yfast.delete(key))
+	}
+
+	return entries
+}
+
+func (yfast *YFastTrie) get(key uint64) Entry {
+	bundleKey := yfast.getBucketKey(key)
+	bundle := yfast.xfast.Get(bundleKey)
+	if bundle == nil {
+		return nil
+	}
+
+	entry := bundle.(*entriesWrapper).entries.get(key)
+	if entry == nil { // go interfaces :(
+		return nil
+	}
+
+	return entry
+}
+
+// Get will look for the provided key in the y-fast trie and return
+// the associated value if it is found.  If it is not found, this
+// method returns nil.
+func (yfast *YFastTrie) Get(key uint64) Entry {
+	entry := yfast.get(key)
+	if entry == nil {
+		return nil
+	}
+
+	return entry
+}
+
+// Len returns the number of items in the y-fast trie.
+func (yfast *YFastTrie) Len() uint64 {
+	return yfast.num
+}
+
+func (yfast *YFastTrie) successor(key uint64) Entry {
+	bundle := yfast.xfast.Successor(key)
+	if bundle == nil {
+		return nil
+	}
+
+	entry, _ := bundle.(*entriesWrapper).entries.successor(key)
+	if entry == nil {
+		return nil
+	}
+
+	return entry
+}
+
+// Successor returns an Entry with a key equal to or immediately
+// greater than the provided key.  If such an Entry does not exist
+// this returns nil.
+func (yfast *YFastTrie) Successor(key uint64) Entry {
+	entry := yfast.successor(key)
+	if entry == nil {
+		return nil
+	}
+
+	return entry
+}
+
+func (yfast *YFastTrie) predecessor(key uint64) Entry {
+	// harder case because our representative value in the
+	// x-fast trie is the a max
+	bundleKey := yfast.getBucketKey(key)
+	bundle := yfast.xfast.Predecessor(bundleKey)
+	if bundle == nil {
+		return nil
+	}
+
+	ew := bundle.(*entriesWrapper)
+	entry, _ := ew.entries.predecessor(key)
+	if entry != nil {
+		return entry
+	}
+
+	// it's possible we do exist somewhere earlier in the x-fast trie
+	bundle = yfast.xfast.Predecessor(bundleKey - 1)
+	if bundle == nil {
+		return nil
+	}
+
+	ew = bundle.(*entriesWrapper)
+
+	entry, _ = ew.entries.predecessor(key)
+	if entry == nil {
+		return nil
+	}
+
+	return entry
+}
+
+// Predecessor returns an Entry with a key equal to or immediately
+// preceeding than the provided key.  If such an Entry does not exist
+// this returns nil.
+func (yfast *YFastTrie) Predecessor(key uint64) Entry {
+	entry := yfast.predecessor(key)
+	if entry == nil {
+		return nil
+	}
+
+	return entry
+}
+
+func (yfast *YFastTrie) iter(key uint64) *Iterator {
+	xfastIter := yfast.xfast.Iter(key)
+	xfastIter.Next()
+	bundle := xfastIter.Value()
+	if bundle == nil {
+		return nilIterator()
+	}
+
+	i := bundle.(*entriesWrapper).entries.search(key)
+	return &Iterator{
+		index:         i - 1,
+		xfastIterator: xfastIter,
+		entries:       bundle.(*entriesWrapper),
+	}
+}
+
+// Iter will return an iterator that will iterate across all values
+// that start or immediately proceed the provided key.  Iteration
+// happens in ascending order.
+func (yfast *YFastTrie) Iter(key uint64) *Iterator {
+	return yfast.iter(key)
+}
+
+// New constructs, initializes, and returns a new y-fast trie.
+// Provided should be a uint type that specifies the number
+// of bits in the desired universe.  This will affect the time
+// complexity of all lookup and mutate operations.
+func New(ifc interface{}) *YFastTrie {
+	yfast := &YFastTrie{}
+	yfast.init(ifc)
+	return yfast
+}

--- a/trie/yfast/yfast.go
+++ b/trie/yfast/yfast.go
@@ -1,4 +1,20 @@
 /*
+Copyright 2014 Workiva, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
 Package yfast implements a y-fast trie.  Instead of a red-black BBST
 for the leaves, this implementation uses a simple ordered list.  This
 package should have searches that are as performant as the x-fast
@@ -14,19 +30,14 @@ Delete: O(log log M)
 where n is the number of items in the trie and M is the size of the
 universe, ie, 2^m where m is the number of bits in the specified key
 size.
+
+This particular implementation also uses fixed bucket sizes as this should
+aid in multithreading these functions for performance optimization.
 */
 
 package yfast
 
-import (
-	"log"
-
-	"github.com/Workiva/go-datastructures/trie/xfast"
-)
-
-func init() {
-	log.Println(`I HATE THIS`)
-}
+import "github.com/Workiva/go-datastructures/trie/xfast"
 
 // YFastTrie implements all the methods available to the y-fast
 // trie datastructure.  The top half is composed of an x-fast trie
@@ -56,6 +67,8 @@ func (yfast *YFastTrie) init(intType interface{}) {
 	yfast.xfast = xfast.New(intType)
 }
 
+// getBucketKey finds the largest possible value in this key's bucket.
+// This is the representative value for the entry in the x-fast trie.
 func (yfast *YFastTrie) getBucketKey(key uint64) uint64 {
 	i := key/uint64(yfast.bits) + 1
 	return uint64(yfast.bits)*i - 1

--- a/trie/yfast/yfast_test.go
+++ b/trie/yfast/yfast_test.go
@@ -1,0 +1,204 @@
+package yfast
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func generateEntries(num int) Entries {
+	entries := make(Entries, 0, num)
+	for i := uint64(0); i < uint64(num); i++ {
+		entries = append(entries, newMockEntry(i))
+	}
+
+	return entries
+}
+
+func TestTrieSimpleInsert(t *testing.T) {
+	yfast := New(uint8(0))
+
+	e1 := newMockEntry(3)
+	e2 := newMockEntry(7)
+	e3 := newMockEntry(8)
+
+	yfast.Insert(e1, e2, e3)
+
+	result := yfast.get(3)
+	assert.Equal(t, e1, result)
+
+	result = yfast.get(7)
+	assert.Equal(t, e2, result)
+
+	result = yfast.get(8)
+	assert.Equal(t, e3, result)
+
+	result = yfast.get(250)
+	assert.Nil(t, result)
+
+	assert.Equal(t, uint64(3), yfast.Len())
+}
+
+func TestTrieDelete(t *testing.T) {
+	yfast := New(uint8(0))
+
+	e1 := newMockEntry(3)
+	e2 := newMockEntry(7)
+	e3 := newMockEntry(8)
+
+	yfast.Insert(e1, e2, e3)
+
+	result := yfast.Delete(3)
+	assert.Equal(t, Entries{e1}, result)
+	assert.Nil(t, yfast.Get(3))
+	assert.Equal(t, uint64(2), yfast.Len())
+
+	result = yfast.Delete(7)
+	assert.Equal(t, Entries{e2}, result)
+	assert.Nil(t, yfast.Get(7))
+	assert.Equal(t, uint64(1), yfast.Len())
+
+	result = yfast.Delete(8)
+	assert.Equal(t, Entries{e3}, result)
+	assert.Nil(t, yfast.Get(8))
+	assert.Equal(t, uint64(0), yfast.Len())
+
+	result = yfast.Delete(5)
+	assert.Equal(t, Entries{nil}, result)
+	assert.Equal(t, uint64(0), yfast.Len())
+}
+
+func TestTrieSuccessor(t *testing.T) {
+	yfast := New(uint8(0))
+
+	e3 := newMockEntry(13)
+	yfast.Insert(e3)
+
+	successor := yfast.Successor(0)
+	assert.Equal(t, e3, successor)
+
+	e1 := newMockEntry(3)
+	e2 := newMockEntry(7)
+
+	yfast.Insert(e1, e2)
+
+	successor = yfast.Successor(0)
+	assert.Equal(t, e1, successor)
+
+	successor = yfast.Successor(3)
+	assert.Equal(t, e1, successor)
+
+	successor = yfast.Successor(4)
+	assert.Equal(t, e2, successor)
+
+	successor = yfast.Successor(8)
+	assert.Equal(t, e3, successor)
+
+	successor = yfast.Successor(14)
+	assert.Nil(t, successor)
+
+	successor = yfast.Successor(100)
+	assert.Nil(t, successor)
+}
+
+func TestTriePredecessor(t *testing.T) {
+	yfast := New(uint8(0))
+
+	predecessor := yfast.Predecessor(5)
+	assert.Nil(t, predecessor)
+
+	e1 := newMockEntry(5)
+	yfast.Insert(e1)
+
+	predecessor = yfast.Predecessor(13)
+	assert.Equal(t, e1, predecessor)
+
+	e2 := newMockEntry(12)
+	yfast.Insert(e2)
+
+	predecessor = yfast.Predecessor(11)
+	assert.Equal(t, e1, predecessor)
+
+	predecessor = yfast.Predecessor(5)
+	assert.Equal(t, e1, predecessor)
+
+	predecessor = yfast.Predecessor(4)
+	assert.Nil(t, predecessor)
+
+	predecessor = yfast.Predecessor(100)
+	assert.Equal(t, e2, predecessor)
+}
+
+func BenchmarkInsert(b *testing.B) {
+	yfast := New(uint64(0))
+	entries := generateEntries(b.N)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		yfast.Insert(entries[i])
+	}
+}
+
+func BenchmarkGet(b *testing.B) {
+	numItems := 1000
+
+	entries := generateEntries(numItems)
+
+	yfast := New(uint32(0))
+	yfast.Insert(entries...)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		yfast.Get(uint64(numItems / 2))
+	}
+}
+
+func BenchmarkDelete(b *testing.B) {
+	entries := generateEntries(b.N)
+	yfast := New(uint64(0))
+	yfast.Insert(entries...)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		yfast.Delete(uint64(i))
+	}
+}
+
+func BenchmarkSuccessor(b *testing.B) {
+	numItems := 100000
+
+	entries := make(Entries, 0, numItems)
+	for i := uint64(0); i < uint64(numItems); i++ {
+		entries = append(entries, newMockEntry(i+uint64(b.N/2)))
+	}
+
+	yfast := New(uint64(0))
+	yfast.Insert(entries...)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		yfast.Successor(uint64(i))
+	}
+}
+
+func BenchmarkPredecessor(b *testing.B) {
+	numItems := 100000
+
+	entries := make(Entries, 0, numItems)
+	for i := uint64(0); i < uint64(numItems); i++ {
+		entries = append(entries, newMockEntry(i+uint64(b.N/2)))
+	}
+
+	yfast := New(uint64(0))
+	yfast.Insert(entries...)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		yfast.Predecessor(uint64(i))
+	}
+}


### PR DESCRIPTION
CODE REVIEW

As promised, here is a y-fast trie implementation.  Instead of a red/black trie for the leaves I used an ordered list as an insertion into that list should be pretty easy on memcopy as the maximum size for the list is log M.  The other benefit of using the list is good cache locality as opposed to a BST.  The upper half of the trie is the x-fast trie I finished up the other day.  The expected complexities of a y-fast trie are as follows:

Space: O(n)
Insert: O(log log M)
Search/Get: O(log log M)
Insert/Delete: O(log log M)

To test the veracity of these numbers, I created some benchmarks in the unit tests which are as follows:
BenchmarkInsert-8	 5000000	       245 ns/op
BenchmarkGet-8	20000000	        82.1 ns/op
BenchmarkDelete-8	10000000	       214 ns/op
BenchmarkSuccessor-8	30000000	        44.1 ns/op
BenchmarkPredecessor-8	30000000	        44.2 ns/op
BenchmarkIterator-8	  200000	      7332 ns/op

So ultimately what we are getting here are benchmarks that are similar to a map (I ran the set benchmark on a map[uint64]Entry and it runs 290 ns if you don't give a size hint and 139 if you do, the y-fast trie doesn't need a size hint), while keeping the data ordered, which allows us to just as quickly check for a value greater or less than and equal to.  We are basically combining the best parts of a map (constant time complexity, near linear space usage) with the best parts of an ordered list (we can iterate the keys in order).

Again, I believe that this is the first and only implementation of a y-fast trie in Go.

I plan on using this as the datastructure backing our n-dimensional rangetree.  I may also make an immutable version of this.

@tannermiller-wf @beaulyddon-wf @alexandercampbell-wf @rosshendrickson-wf @ericolson-wf @tylertreat-wf @stevenosborne-wf 