### PR TITLE
Skip list

### DIFF
--- a/slice/skip/interface.go
+++ b/slice/skip/interface.go
@@ -1,0 +1,11 @@
+package skip
+
+// Entry defines items that can be inserted into the skip list.
+// This will also be the type returned from a query.
+type Entry interface {
+	// Key defines this entry's place in the skip list.
+	Key() uint64
+}
+
+// Entries is a typed list of interface Entry.
+type Entries []Entry

--- a/slice/skip/interface.go
+++ b/slice/skip/interface.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2014 Workiva, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package skip
 
 // Entry defines items that can be inserted into the skip list.

--- a/slice/skip/iterator.go
+++ b/slice/skip/iterator.go
@@ -1,0 +1,52 @@
+package skip
+
+// Iterator represents an object that can be iterated.  It will
+// return false on Next and nil on Value if there are no further
+// values to be iterated.
+type Iterator struct {
+	first bool
+	n     *node
+}
+
+// Next returns a bool indicating if there are any further values
+// in this iterator.
+func (iter *Iterator) Next() bool {
+	if iter.first {
+		iter.first = false
+		return iter.n != nil
+	}
+
+	if iter.n == nil {
+		return false
+	}
+
+	iter.n = iter.n.forward[0]
+	return iter.n != nil
+}
+
+// Value returns an Entry representing the iterator's present
+// position in the query.  Returns nil if no values remain to iterate.
+func (iter *Iterator) Value() Entry {
+	if iter.n == nil {
+		return nil
+	}
+
+	return iter.n.entry
+}
+
+// exhaust is a helper method to exhaust this iterator and return
+// all remaining entries.
+func (iter *Iterator) exhaust() Entries {
+	entries := make(Entries, 0, 10)
+	for i := iter; i.Next(); {
+		entries = append(entries, i.Value())
+	}
+
+	return entries
+}
+
+// nilIterator returns an iterator that will always return false
+// for Next and nil for Value.
+func nilIterator() *Iterator {
+	return &Iterator{}
+}

--- a/slice/skip/iterator.go
+++ b/slice/skip/iterator.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2014 Workiva, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package skip
 
 // Iterator represents an object that can be iterated.  It will

--- a/slice/skip/iterator_test.go
+++ b/slice/skip/iterator_test.go
@@ -1,0 +1,41 @@
+package skip
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIterate(t *testing.T) {
+	e1 := newMockEntry(1)
+	n1 := newNode(e1, 8)
+	iter := &Iterator{
+		n:     n1,
+		first: true,
+	}
+
+	assert.True(t, iter.Next())
+	assert.Equal(t, e1, iter.Value())
+	assert.False(t, iter.Next())
+	assert.Nil(t, iter.Value())
+
+	e2 := newMockEntry(2)
+	n2 := newNode(e2, 8)
+	n1.forward[0] = n2
+
+	iter = &Iterator{
+		n:     n1,
+		first: true,
+	}
+
+	assert.True(t, iter.Next())
+	assert.Equal(t, e1, iter.Value())
+	assert.True(t, iter.Next())
+	assert.Equal(t, e2, iter.Value())
+	assert.False(t, iter.Next())
+	assert.Nil(t, iter.Value())
+
+	iter = nilIterator()
+	assert.False(t, iter.Next())
+	assert.Nil(t, iter.Value())
+}

--- a/slice/skip/iterator_test.go
+++ b/slice/skip/iterator_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2014 Workiva, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package skip
 
 import (

--- a/slice/skip/mock_test.go
+++ b/slice/skip/mock_test.go
@@ -1,0 +1,13 @@
+package skip
+
+type mockEntry struct {
+	key uint64
+}
+
+func (me *mockEntry) Key() uint64 {
+	return me.key
+}
+
+func newMockEntry(key uint64) *mockEntry {
+	return &mockEntry{key}
+}

--- a/slice/skip/mock_test.go
+++ b/slice/skip/mock_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2014 Workiva, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package skip
 
 type mockEntry struct {

--- a/slice/skip/node.go
+++ b/slice/skip/node.go
@@ -1,7 +1,24 @@
+/*
+Copyright 2014 Workiva, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package skip
 
 type nodes []*node
 
+// reset will mark every index in this list of nodes as nil.
 func (ns nodes) reset() nodes {
 	for i := range ns {
 		ns[i] = nil
@@ -14,13 +31,19 @@ type node struct {
 	// forward denotes the forward pointing pointers in this
 	// node.
 	forward nodes
-	entry   Entry
+	// entry is the associated value with this node.
+	entry Entry
 }
 
+// key is a helper method to return the key of the entry associated
+// with this node.
 func (n *node) key() uint64 {
 	return n.entry.Key()
 }
 
+// newNode will allocate and return a new node with the entry
+// provided.  maxLevels will determine the length of the forward
+// pointer list associated with this node.
 func newNode(entry Entry, maxLevels uint8) *node {
 	return &node{
 		entry:   entry,

--- a/slice/skip/node.go
+++ b/slice/skip/node.go
@@ -1,0 +1,29 @@
+package skip
+
+type nodes []*node
+
+func (ns nodes) reset() nodes {
+	for i := range ns {
+		ns[i] = nil
+	}
+
+	return ns
+}
+
+type node struct {
+	// forward denotes the forward pointing pointers in this
+	// node.
+	forward nodes
+	entry   Entry
+}
+
+func (n *node) key() uint64 {
+	return n.entry.Key()
+}
+
+func newNode(entry Entry, maxLevels uint8) *node {
+	return &node{
+		entry:   entry,
+		forward: make(nodes, maxLevels),
+	}
+}

--- a/slice/skip/skip.go
+++ b/slice/skip/skip.go
@@ -35,6 +35,10 @@ func generateLevel(maxLevel uint8) uint8 {
 	return level
 }
 
+// Skip list is a datastructure that probabalistically determines
+// relationships between nodes.  This results in a structure
+// that performs similarly to a BST but is much easier to build
+// from a programmatic perspective (no rotations).
 type SkipList struct {
 	maxLevel, level uint8
 	head, tail      *node
@@ -83,6 +87,9 @@ func (sl *SkipList) search(key uint64, update []*node) *node {
 	return n.forward[0]
 }
 
+// Get will retrieve values associated with the keys provided.  If an
+// associated value could not be found, a nil is returned in its place.
+// This is an O(log n) operation.
 func (sl *SkipList) Get(keys ...uint64) Entries {
 	entries := make(Entries, 0, len(keys))
 
@@ -163,6 +170,9 @@ func (sl *SkipList) delete(key uint64) Entry {
 	return n.entry
 }
 
+// Delete will remove the provided keys from the skiplist and return
+// a list of in-order entries that were deleted.  This is a no-op if
+// an associated key could not be found.  This is an O(log n) operation.
 func (sl *SkipList) Delete(keys ...uint64) Entries {
 	deleted := make(Entries, 0, len(keys))
 
@@ -178,6 +188,30 @@ func (sl *SkipList) Len() uint64 {
 	return sl.num
 }
 
+func (sl *SkipList) iter(key uint64) *Iterator {
+	n := sl.search(key, nil)
+	if n == nil {
+		return nilIterator()
+	}
+
+	return &Iterator{
+		first: true,
+		n:     n,
+	}
+}
+
+// Iter will return an iterator that can be used to iterate
+// over all the values with a key equal to or greater than
+// the key provided.
+func (sl *SkipList) Iter(key uint64) *Iterator {
+	return sl.iter(key)
+}
+
+// New will allocate, initialize, and return a new skiplist.
+// The provided parameter should be of type uint and will determine
+// the maximum possible level that will be created to ensure
+// a random and quick distribution of levels.  Parameter must
+// be a uint type.
 func New(ifc interface{}) *SkipList {
 	sl := &SkipList{}
 	sl.init(ifc)

--- a/slice/skip/skip.go
+++ b/slice/skip/skip.go
@@ -1,0 +1,185 @@
+package skip
+
+import (
+	"log"
+	"math/rand"
+	"time"
+)
+
+func init() {
+	log.Printf(`I HATE THIS.`)
+}
+
+const p = .5 // the p level defines the probability that a node
+// with a value at level i also has a value at i+1.  This number
+// is also important in determining max level.  Max level will
+// be defined as L(N) where L = log base (1/p) of n where n
+// is the number of items in the list and N is the number of possible
+// items in the universe.  If p = .5 then maxlevel = 32 is appropriate
+// for uint32.
+
+// generator will be the common generator to create random numbers. It
+// is seeded with unix nanosecond when this line is executed at runtime,
+// and only executed once ensuring all random numbers come from the same
+// randomly seeded generator.
+var generator = rand.New(rand.NewSource(time.Now().UnixNano()))
+
+func generateLevel(maxLevel uint8) uint8 {
+	var level uint8
+	for level = uint8(1); level < maxLevel-1; level++ {
+		if generator.Float64() >= p {
+			return level
+		}
+	}
+
+	return level
+}
+
+type SkipList struct {
+	maxLevel, level uint8
+	head, tail      *node
+	num             uint64
+	// a list of nodes that can be reused, should reduce
+	// the number of allocations in the insert/delete case.
+	cache nodes
+}
+
+// init will initialize this skiplist.  The parameter is expected
+// to be of some uint type which will set this skiplist's maximum
+// level.
+func (sl *SkipList) init(ifc interface{}) {
+	switch ifc.(type) {
+	case uint8:
+		sl.maxLevel = 8
+	case uint16:
+		sl.maxLevel = 16
+	case uint32:
+		sl.maxLevel = 32
+	case uint64, uint:
+		sl.maxLevel = 64
+	}
+	sl.cache = make(nodes, sl.maxLevel)
+	sl.head = newNode(nil, sl.maxLevel)
+}
+
+func (sl *SkipList) search(key uint64, update []*node) *node {
+	if sl.num == 0 { // nothing in the list
+		return nil
+	}
+
+	var offset uint8
+	n := sl.head
+	for i := uint8(0); i <= sl.level; i++ {
+		offset = sl.level - i
+		for n.forward[offset] != nil && n.forward[offset].key() < key {
+			n = n.forward[offset]
+		}
+
+		if update != nil {
+			update[offset] = n
+		}
+	}
+
+	return n.forward[0]
+}
+
+func (sl *SkipList) Get(keys ...uint64) Entries {
+	entries := make(Entries, 0, len(keys))
+
+	var n *node
+	for _, key := range keys {
+		n = sl.search(key, nil)
+		if n == nil {
+			entries = append(entries, nil)
+		} else {
+			entries = append(entries, n.entry)
+		}
+	}
+
+	return entries
+}
+
+func (sl *SkipList) insert(entry Entry) Entry {
+	sl.cache.reset()
+	n := sl.search(entry.Key(), sl.cache)
+	if n != nil && n.key() == entry.Key() { // a simple update in this case
+		oldEntry := n.entry
+		n.entry = entry
+		return oldEntry
+	}
+	sl.num++
+
+	nodeLevel := generateLevel(sl.maxLevel)
+	if nodeLevel > sl.level {
+		for i := sl.level; i <= nodeLevel; i++ {
+			sl.cache[i] = sl.head
+		}
+		sl.level = nodeLevel
+	}
+
+	nn := newNode(entry, sl.maxLevel)
+	for i := uint8(0); i <= nodeLevel; i++ {
+		nn.forward[i] = sl.cache[i].forward[i]
+		sl.cache[i].forward[i] = nn
+	}
+
+	return nil
+}
+
+// Insert will insert the provided entries into the list.  Returned
+// is a list of entries that were overwritten.  This is expected to
+// be an O(log n) operation.
+func (sl *SkipList) Insert(entries ...Entry) Entries {
+	overwritten := make(Entries, 0, len(entries))
+	for _, e := range entries {
+		overwritten = append(overwritten, sl.insert(e))
+	}
+
+	return overwritten
+}
+
+func (sl *SkipList) delete(key uint64) Entry {
+	sl.cache.reset()
+	n := sl.search(key, sl.cache)
+
+	if n == nil || n.entry.Key() != key {
+		return nil
+	}
+
+	sl.num--
+
+	for i := uint8(0); i <= sl.level; i++ {
+		if sl.cache[i].forward[i] != n {
+			break
+		}
+
+		sl.cache[i].forward[i] = n.forward[i]
+	}
+
+	for sl.level > 0 && sl.head.forward[sl.level] == nil {
+		sl.level = sl.level - 1
+	}
+
+	return n.entry
+}
+
+func (sl *SkipList) Delete(keys ...uint64) Entries {
+	deleted := make(Entries, 0, len(keys))
+
+	for _, key := range keys {
+		deleted = append(deleted, sl.delete(key))
+	}
+
+	return deleted
+}
+
+// Len returns the number of items in this skiplist.
+func (sl *SkipList) Len() uint64 {
+	return sl.num
+}
+
+func New(ifc interface{}) *SkipList {
+	sl := &SkipList{}
+	sl.init(ifc)
+	return sl
+}

--- a/slice/skip/skip.go
+++ b/slice/skip/skip.go
@@ -1,14 +1,40 @@
+/*
+Copyright 2014 Workiva, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package skip defines a skiplist datastructure.  That is, a data structure
+that probabilistically determines relationships between keys.  By doing
+so, it becomes easier to program than a binary search tree but maintains
+similar speeds.
+
+Performance characteristics:
+Insert: O(log n)
+Search: O(log n)
+Delete: O(log n)
+Space: O(n)
+
+More information here: http://cglab.ca/~morin/teaching/5408/refs/p90b.pdf
+*/
+
 package skip
 
 import (
-	"log"
 	"math/rand"
 	"time"
 )
-
-func init() {
-	log.Printf(`I HATE THIS.`)
-}
 
 const p = .5 // the p level defines the probability that a node
 // with a value at level i also has a value at i+1.  This number
@@ -41,7 +67,7 @@ func generateLevel(maxLevel uint8) uint8 {
 // from a programmatic perspective (no rotations).
 type SkipList struct {
 	maxLevel, level uint8
-	head, tail      *node
+	head            *node
 	num             uint64
 	// a list of nodes that can be reused, should reduce
 	// the number of allocations in the insert/delete case.

--- a/slice/skip/skip_test.go
+++ b/slice/skip/skip_test.go
@@ -126,7 +126,7 @@ func TestIter(t *testing.T) {
 }
 
 func BenchmarkInsert(b *testing.B) {
-	numItems := 10000
+	numItems := b.N
 	sl := New(uint64(0))
 
 	entries := generateMockEntries(numItems)
@@ -139,7 +139,7 @@ func BenchmarkInsert(b *testing.B) {
 }
 
 func BenchmarkGet(b *testing.B) {
-	numItems := 10000
+	numItems := b.N
 	sl := New(uint64(0))
 
 	entries := generateMockEntries(numItems)

--- a/slice/skip/skip_test.go
+++ b/slice/skip/skip_test.go
@@ -1,0 +1,116 @@
+package skip
+
+import (
+	"log"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func init() {
+	log.Printf(`BOTCHED.`)
+}
+
+func generateMockEntries(num int) Entries {
+	entries := make(Entries, 0, num)
+	for i := uint64(0); i < uint64(num); i++ {
+		entries = append(entries, newMockEntry(i))
+	}
+
+	return entries
+}
+
+func TestSimpleInsert(t *testing.T) {
+	m1 := newMockEntry(5)
+	m2 := newMockEntry(6)
+
+	sl := New(uint8(0))
+
+	overwritten := sl.Insert(m1)
+	assert.Equal(t, Entries{m1}, sl.Get(5))
+	assert.Equal(t, uint64(1), sl.Len())
+	assert.Equal(t, Entries{nil}, overwritten)
+
+	overwritten = sl.Insert(m2)
+	assert.Equal(t, Entries{m2}, sl.Get(6))
+	assert.Equal(t, Entries{nil}, sl.Get(7))
+	assert.Equal(t, uint64(2), sl.Len())
+	assert.Equal(t, Entries{nil}, overwritten)
+}
+
+func TestSimpleOverwrite(t *testing.T) {
+	m1 := newMockEntry(5)
+	m2 := newMockEntry(5)
+
+	sl := New(uint8(0))
+
+	overwritten := sl.Insert(m1)
+	assert.Equal(t, Entries{nil}, overwritten)
+	assert.Equal(t, uint64(1), sl.Len())
+
+	overwritten = sl.Insert(m2)
+	assert.Equal(t, Entries{m1}, overwritten)
+	assert.Equal(t, uint64(1), sl.Len())
+}
+
+func TestInsertOutOfOrder(t *testing.T) {
+	m1 := newMockEntry(6)
+	m2 := newMockEntry(5)
+
+	sl := New(uint8(0))
+
+	overwritten := sl.Insert(m1, m2)
+	assert.Equal(t, Entries{nil, nil}, overwritten)
+
+	assert.Equal(t, Entries{m1, m2}, sl.Get(6, 5))
+}
+
+func TestDelete(t *testing.T) {
+	m1 := newMockEntry(5)
+	sl := New(uint8(0))
+	sl.Insert(m1)
+
+	deleted := sl.Delete(m1.Key())
+	assert.Equal(t, Entries{m1}, deleted)
+	assert.Equal(t, uint64(0), sl.Len())
+	assert.Equal(t, Entries{nil}, sl.Get(5))
+}
+
+func TestDeleteAll(t *testing.T) {
+	m1 := newMockEntry(5)
+	m2 := newMockEntry(6)
+	sl := New(uint8(0))
+	sl.Insert(m1, m2)
+
+	deleted := sl.Delete(m1.Key(), m2.Key())
+	assert.Equal(t, Entries{m1, m2}, deleted)
+	assert.Equal(t, uint64(0), sl.Len())
+	assert.Equal(t, Entries{nil, nil}, sl.Get(m1.Key(), m2.Key()))
+}
+
+func BenchmarkInsert(b *testing.B) {
+	numItems := 10000
+	sl := New(uint64(0))
+
+	entries := generateMockEntries(numItems)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		sl.Insert(entries[i%numItems])
+	}
+}
+
+func BenchmarkGet(b *testing.B) {
+	numItems := 10000
+	sl := New(uint64(0))
+
+	entries := generateMockEntries(numItems)
+	sl.Insert(entries...)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		sl.Get(entries[i%numItems].Key())
+	}
+}

--- a/slice/skip/skip_test.go
+++ b/slice/skip/skip_test.go
@@ -1,15 +1,26 @@
+/*
+Copyright 2014 Workiva, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package skip
 
 import (
-	"log"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
-
-func init() {
-	log.Printf(`BOTCHED.`)
-}
 
 func generateMockEntries(num int) Entries {
 	entries := make(Entries, 0, num)

--- a/slice/skip/skip_test.go
+++ b/slice/skip/skip_test.go
@@ -74,6 +74,9 @@ func TestDelete(t *testing.T) {
 	assert.Equal(t, Entries{m1}, deleted)
 	assert.Equal(t, uint64(0), sl.Len())
 	assert.Equal(t, Entries{nil}, sl.Get(5))
+
+	deleted = sl.Delete(5)
+	assert.Equal(t, Entries{nil}, deleted)
 }
 
 func TestDeleteAll(t *testing.T) {
@@ -86,6 +89,29 @@ func TestDeleteAll(t *testing.T) {
 	assert.Equal(t, Entries{m1, m2}, deleted)
 	assert.Equal(t, uint64(0), sl.Len())
 	assert.Equal(t, Entries{nil, nil}, sl.Get(m1.Key(), m2.Key()))
+}
+
+func TestIter(t *testing.T) {
+	sl := New(uint8(0))
+	m1 := newMockEntry(5)
+	m2 := newMockEntry(10)
+
+	sl.Insert(m1, m2)
+
+	iter := sl.Iter(0)
+	assert.Equal(t, Entries{m1, m2}, iter.exhaust())
+
+	iter = sl.Iter(5)
+	assert.Equal(t, Entries{m1, m2}, iter.exhaust())
+
+	iter = sl.Iter(6)
+	assert.Equal(t, Entries{m2}, iter.exhaust())
+
+	iter = sl.Iter(10)
+	assert.Equal(t, Entries{m2}, iter.exhaust())
+
+	iter = sl.Iter(11)
+	assert.Equal(t, Entries{}, iter.exhaust())
 }
 
 func BenchmarkInsert(b *testing.B) {
@@ -112,5 +138,19 @@ func BenchmarkGet(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		sl.Get(entries[i%numItems].Key())
+	}
+}
+
+func BenchmarkDelete(b *testing.B) {
+	numItems := b.N
+	sl := New(uint64(0))
+
+	entries := generateMockEntries(numItems)
+	sl.Insert(entries...)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		sl.Delete(entries[i].Key())
 	}
 }


### PR DESCRIPTION
CODE REVIEW

This is a basic implementation of a skip list with add/delete/get/iterate functionality.  I think there are some optimizations that can be made here, and I believe I can combine some aspects of this with some concepts from the y-fast trie to generate a new type of datastructure with excellent cache locality.  

Benchmarks:
BenchmarkInsert-8	 1000000	      1104 ns/op
BenchmarkGet-8	 3000000	       547 ns/op
BenchmarkDelete-8	 3000000	       483 ns/op

These numbers are not deterministic due to the nature of how a skip list works, so they may fluctuate between runs.

@alexandercampbell-wf @beaulyddon-wf @tannermiller-wf @rosshendrickson-wf @ericolson-wf @stevenosborne-wf @tylertreat-wf 