### PR TITLE
SkipList*

### DIFF
--- a/rangetree/ordered_test.go
+++ b/rangetree/ordered_test.go
@@ -139,3 +139,18 @@ func TestInsertDelete(t *testing.T) {
 	assert.Len(t, ns, 0)
 	assert.Equal(t, Entries{n2.entry, n3.entry, n1.entry}, deleted)
 }
+
+func BenchmarkPrepend(b *testing.B) {
+	numItems := 100000
+	ns := make(orderedNodes, 0, numItems)
+
+	for i := b.N; i < b.N+numItems; i++ {
+		ns.add(newNode(int64(i), constructMockEntry(uint64(i), int64(i)), false))
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		ns.add(newNode(int64(i), constructMockEntry(uint64(i), int64(i)), false))
+	}
+}

--- a/slice/skip/entries.go
+++ b/slice/skip/entries.go
@@ -1,0 +1,58 @@
+package skip
+
+import "sort"
+
+func (entries Entries) search(key uint64) int {
+	return sort.Search(len(entries), func(i int) bool {
+		return entries[i].Key() >= key
+	})
+}
+
+func (entries *Entries) insert(entry Entry) Entry {
+	i := entries.search(entry.Key())
+	if i >= len(*entries) {
+		*entries = append(*entries, entry)
+		return nil
+	}
+
+	if (*entries)[i].Key() == entry.Key() {
+		oldEntry := (*entries)[i]
+		(*entries)[i] = entry
+		return oldEntry
+	}
+
+	*entries = append(*entries, nil)
+	copy((*entries)[i+1:], (*entries)[i:])
+	(*entries)[i] = entry
+	return nil
+}
+
+func (entries *Entries) delete(key uint64) Entry {
+	i := entries.search(key)
+	if i >= len(*entries) {
+		return nil
+	}
+
+	if (*entries)[i].Key() != key {
+		return nil
+	}
+
+	oldEntry := (*entries)[i]
+	copy((*entries)[i:], (*entries)[i+1:])
+	(*entries)[len(*entries)-1] = nil
+	*entries = (*entries)[:len(*entries)-1]
+	return oldEntry
+}
+
+func (entries Entries) get(key uint64) Entry {
+	i := entries.search(key)
+	if i >= len(entries) {
+		return nil
+	}
+
+	if entries[i].Key() == key {
+		return entries[i]
+	}
+
+	return nil
+}

--- a/slice/skip/entries.go
+++ b/slice/skip/entries.go
@@ -18,12 +18,17 @@ package skip
 
 import "sort"
 
+// search will look for the provided key and return the index
+// where that key would be inserted in this list.  This could
+// be equal to the length of the list which means no suitable entry
+// point was found.
 func (entries Entries) search(key uint64) int {
 	return sort.Search(len(entries), func(i int) bool {
 		return entries[i].Key() >= key
 	})
 }
 
+// insert will insert the provided entry into this list.
 func (entries *Entries) insert(entry Entry) Entry {
 	i := entries.search(entry.Key())
 	if i >= len(*entries) {
@@ -43,6 +48,7 @@ func (entries *Entries) insert(entry Entry) Entry {
 	return nil
 }
 
+// delete will delete the provided key from this list.
 func (entries *Entries) delete(key uint64) Entry {
 	i := entries.search(key)
 	if i >= len(*entries) {
@@ -60,6 +66,8 @@ func (entries *Entries) delete(key uint64) Entry {
 	return oldEntry
 }
 
+// get will return the entry associated with the provided key.
+// If no such Entry exists, this returns nil.
 func (entries Entries) get(key uint64) Entry {
 	i := entries.search(key)
 	if i >= len(entries) {

--- a/slice/skip/entries.go
+++ b/slice/skip/entries.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2014 Workiva, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package skip
 
 import "sort"

--- a/slice/skip/entries_test.go
+++ b/slice/skip/entries_test.go
@@ -1,0 +1,46 @@
+package skip
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEntriesInsert(t *testing.T) {
+	e1 := newMockEntry(10)
+	e2 := newMockEntry(5)
+
+	entries := Entries{e1}
+	result := entries.insert(e2)
+	assert.Equal(t, Entries{e2, e1}, entries)
+	assert.Nil(t, result)
+
+	e3 := newMockEntry(15)
+	result = entries.insert(e3)
+	assert.Equal(t, Entries{e2, e1, e3}, entries)
+	assert.Nil(t, result)
+}
+
+func TestInsertOverwrite(t *testing.T) {
+	e1 := newMockEntry(10)
+	e2 := newMockEntry(10)
+
+	entries := Entries{e1}
+	result := entries.insert(e2)
+	assert.Equal(t, e1, result)
+}
+
+func TestEntriesDelete(t *testing.T) {
+	e1 := newMockEntry(5)
+	e2 := newMockEntry(10)
+
+	entries := Entries{e1, e2}
+
+	result := entries.delete(10)
+	assert.Equal(t, Entries{e1}, entries)
+	assert.Equal(t, e2, result)
+
+	result = entries.delete(5)
+	assert.Equal(t, Entries{}, entries)
+	assert.Equal(t, e1, result)
+}

--- a/slice/skip/entries_test.go
+++ b/slice/skip/entries_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2014 Workiva, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package skip
 
 import (

--- a/slice/skip/interface.go
+++ b/slice/skip/interface.go
@@ -25,3 +25,9 @@ type Entry interface {
 
 // Entries is a typed list of interface Entry.
 type Entries []Entry
+
+type Iterator interface {
+	Next() bool
+	Value() Entry
+	exhaust() Entries
+}

--- a/slice/skip/interface.go
+++ b/slice/skip/interface.go
@@ -26,8 +26,17 @@ type Entry interface {
 // Entries is a typed list of interface Entry.
 type Entries []Entry
 
+// Iterator defines an interface that allows a consumer to iterate
+// all results of a query.  All values will be visited in-order.
 type Iterator interface {
+	// Next returns a bool indicating if there is future value
+	// in the iterator and moves the iterator to that value.
 	Next() bool
+	// Value returns an Entry representing the iterator's current
+	// position.  If there is no value, this returns nil.
 	Value() Entry
+	// exhaust is a helper method that will iterate this iterator
+	// to completion and return a list of resulting Entries
+	// in order.
 	exhaust() Entries
 }

--- a/slice/skip/iterator.go
+++ b/slice/skip/iterator.go
@@ -18,7 +18,7 @@ package skip
 
 const iteratorExhausted = -2
 
-// Iterator represents an object that can be iterated.  It will
+// iterator represents an object that can be iterated.  It will
 // return false on Next and nil on Value if there are no further
 // values to be iterated.
 type iterator struct {
@@ -69,16 +69,21 @@ func nilIterator() *iterator {
 	return &iterator{}
 }
 
+// starIterator is used as an iterator by the SkipList*.
 type starIterator struct {
 	entries Entries
 	iter    Iterator
 	index   int
 }
 
+// isExhausted returns a bool indicating if all values have been
+// iterated.
 func (si *starIterator) isExhausted() bool {
 	return si.index == iteratorExhausted
 }
 
+// Next returns a bool indicating if there are any further values
+// in this iterator.
 func (si *starIterator) Next() bool {
 	if si.isExhausted() {
 		return false
@@ -99,6 +104,8 @@ func (si *starIterator) Next() bool {
 	return true
 }
 
+// Value returns an Entry representing the iterator's present
+// position in the query.  Returns nil if no values remain to iterate.
 func (si *starIterator) Value() Entry {
 	if si.isExhausted() {
 		return nil

--- a/slice/skip/iterator.go
+++ b/slice/skip/iterator.go
@@ -16,17 +16,19 @@ limitations under the License.
 
 package skip
 
+const iteratorExhausted = -2
+
 // Iterator represents an object that can be iterated.  It will
 // return false on Next and nil on Value if there are no further
 // values to be iterated.
-type Iterator struct {
+type iterator struct {
 	first bool
 	n     *node
 }
 
 // Next returns a bool indicating if there are any further values
 // in this iterator.
-func (iter *Iterator) Next() bool {
+func (iter *iterator) Next() bool {
 	if iter.first {
 		iter.first = false
 		return iter.n != nil
@@ -42,7 +44,7 @@ func (iter *Iterator) Next() bool {
 
 // Value returns an Entry representing the iterator's present
 // position in the query.  Returns nil if no values remain to iterate.
-func (iter *Iterator) Value() Entry {
+func (iter *iterator) Value() Entry {
 	if iter.n == nil {
 		return nil
 	}
@@ -52,7 +54,7 @@ func (iter *Iterator) Value() Entry {
 
 // exhaust is a helper method to exhaust this iterator and return
 // all remaining entries.
-func (iter *Iterator) exhaust() Entries {
+func (iter *iterator) exhaust() Entries {
 	entries := make(Entries, 0, 10)
 	for i := iter; i.Next(); {
 		entries = append(entries, i.Value())
@@ -63,6 +65,57 @@ func (iter *Iterator) exhaust() Entries {
 
 // nilIterator returns an iterator that will always return false
 // for Next and nil for Value.
-func nilIterator() *Iterator {
-	return &Iterator{}
+func nilIterator() *iterator {
+	return &iterator{}
+}
+
+type starIterator struct {
+	entries Entries
+	iter    Iterator
+	index   int
+}
+
+func (si *starIterator) isExhausted() bool {
+	return si.index == iteratorExhausted
+}
+
+func (si *starIterator) Next() bool {
+	if si.isExhausted() {
+		return false
+	}
+
+	si.index++
+	if si.index >= len(si.entries) {
+		canNext := si.iter.Next()
+		if !canNext {
+			si.index = iteratorExhausted
+			return false
+		}
+
+		si.entries = si.iter.Value().(*entryBundle).entries
+		si.index = 0
+	}
+
+	return true
+}
+
+func (si *starIterator) Value() Entry {
+	if si.isExhausted() {
+		return nil
+	}
+
+	if si.entries == nil || si.index < 0 || si.index >= len(si.entries) {
+		return nil
+	}
+
+	return si.entries[si.index]
+}
+
+func (si *starIterator) exhaust() Entries {
+	entries := make(Entries, 0, 20)
+	for i := si; i.Next(); {
+		entries = append(entries, i.Value())
+	}
+
+	return entries
 }

--- a/slice/skip/iterator_test.go
+++ b/slice/skip/iterator_test.go
@@ -25,7 +25,7 @@ import (
 func TestIterate(t *testing.T) {
 	e1 := newMockEntry(1)
 	n1 := newNode(e1, 8)
-	iter := &Iterator{
+	iter := &iterator{
 		n:     n1,
 		first: true,
 	}
@@ -39,7 +39,7 @@ func TestIterate(t *testing.T) {
 	n2 := newNode(e2, 8)
 	n1.forward[0] = n2
 
-	iter = &Iterator{
+	iter = &iterator{
 		n:     n1,
 		first: true,
 	}
@@ -54,4 +54,32 @@ func TestIterate(t *testing.T) {
 	iter = nilIterator()
 	assert.False(t, iter.Next())
 	assert.Nil(t, iter.Value())
+}
+
+func TestStarIterate(t *testing.T) {
+	e1 := newMockEntry(1)
+	e2 := newMockEntry(3)
+	e3 := newMockEntry(4)
+
+	i1 := &starIterator{
+		entries: Entries{e1},
+		index:   -1,
+	}
+
+	i2 := new(mockIterator)
+	i2.On(`Next`).Return(true).Once()
+	i2.On(`Next`).Return(false).Once()
+	i2.On(`Value`).Return(&entryBundle{entries: Entries{e2, e3}}).Once()
+	i2.On(`Value`).Return(nil).Once()
+
+	i1.iter = i2
+
+	assert.True(t, i1.Next())
+	assert.Equal(t, e1, i1.Value())
+	assert.True(t, i1.Next())
+	assert.Equal(t, e2, i1.Value())
+	assert.True(t, i1.Next())
+	assert.Equal(t, e3, i1.Value())
+	assert.False(t, i1.Next())
+	assert.Nil(t, i1.Value())
 }

--- a/slice/skip/mock_test.go
+++ b/slice/skip/mock_test.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package skip
 
+import "github.com/stretchr/testify/mock"
+
 type mockEntry struct {
 	key uint64
 }
@@ -26,4 +28,27 @@ func (me *mockEntry) Key() uint64 {
 
 func newMockEntry(key uint64) *mockEntry {
 	return &mockEntry{key}
+}
+
+type mockIterator struct {
+	mock.Mock
+}
+
+func (mi *mockIterator) Next() bool {
+	args := mi.Called()
+	return args.Bool(0)
+}
+
+func (mi *mockIterator) Value() Entry {
+	args := mi.Called()
+	result, ok := args.Get(0).(Entry)
+	if !ok {
+		return nil
+	}
+
+	return result
+}
+
+func (mi *mockIterator) exhaust() Entries {
+	return nil
 }

--- a/slice/skip/skip.go
+++ b/slice/skip/skip.go
@@ -214,13 +214,13 @@ func (sl *SkipList) Len() uint64 {
 	return sl.num
 }
 
-func (sl *SkipList) iter(key uint64) *Iterator {
+func (sl *SkipList) iter(key uint64) *iterator {
 	n := sl.search(key, nil)
 	if n == nil {
 		return nilIterator()
 	}
 
-	return &Iterator{
+	return &iterator{
 		first: true,
 		n:     n,
 	}
@@ -229,7 +229,7 @@ func (sl *SkipList) iter(key uint64) *Iterator {
 // Iter will return an iterator that can be used to iterate
 // over all the values with a key equal to or greater than
 // the key provided.
-func (sl *SkipList) Iter(key uint64) *Iterator {
+func (sl *SkipList) Iter(key uint64) Iterator {
 	return sl.iter(key)
 }
 

--- a/slice/skip/skip.go
+++ b/slice/skip/skip.go
@@ -101,7 +101,7 @@ func (sl *SkipList) search(key uint64, update []*node) *node {
 	n := sl.head
 	for i := uint8(0); i <= sl.level; i++ {
 		offset = sl.level - i
-		for n.forward[offset] != nil && n.forward[offset].key() < key {
+		for n.forward[offset] != nil && n.forward[offset].entry.Key() < key {
 			n = n.forward[offset]
 		}
 

--- a/slice/skip/skip_test.go
+++ b/slice/skip/skip_test.go
@@ -165,3 +165,21 @@ func BenchmarkDelete(b *testing.B) {
 		sl.Delete(entries[i].Key())
 	}
 }
+
+func BenchmarkPrepend(b *testing.B) {
+	numItems := b.N
+	sl := New(uint64(0))
+
+	entries := make(Entries, 0, numItems)
+	for i := b.N; i < b.N+numItems; i++ {
+		entries = append(entries, newMockEntry(uint64(i)))
+	}
+
+	sl.Insert(entries...)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		sl.Insert(newMockEntry(uint64(i)))
+	}
+}

--- a/slice/skip/skipstar.go
+++ b/slice/skip/skipstar.go
@@ -23,12 +23,16 @@ over a standard skip list.  This also keeps any memcopy operation limited
 to O(log M) where M is the size of the desired universe.
 
 Performance vs standard skip list.
-BenchmarkInsert-8	 2000000	       949 ns/op
-BenchmarkGet-8	 3000000	       516 ns/op
-BenchmarkDelete-8	 3000000	       499 ns/op
-BenchmarkStarInsert-8	 3000000	       453 ns/op
-BenchmarkStarGet-8	 3000000	       524 ns/op
-BenchmarkStarDelete-8	 3000000	       469 ns/op
+BenchmarkInsert-8	 2000000	       976 ns/op
+BenchmarkGet-8	 3000000	       442 ns/op
+BenchmarkDelete-8	 3000000	       426 ns/op
+BenchmarkPrepend-8	 2000000	       932 ns/op
+BenchmarkStarInsert-8	 3000000	       398 ns/op
+BenchmarkStarGet-8	 5000000	       488 ns/op
+BenchmarkStarDelete-8	 3000000	       440 ns/op
+BenchmarkIterStar-8	   30000	    122984 ns/op
+BenchmarkStarPrepend-8	 3000000	       618 ns/op
+
 */
 package skip
 

--- a/slice/skip/skipstar.go
+++ b/slice/skip/skipstar.go
@@ -40,7 +40,7 @@ func init() {
 
 // SkipList* implements all methods of a standard skip list but attempts
 // to improve performance by ensuring cache locality.
-type SkipStarList struct {
+type SkipListStar struct {
 	ary uint8
 	num uint64
 	sl  *SkipList
@@ -66,7 +66,7 @@ func newEntryBundle(key uint64, size uint8) *entryBundle {
 	}
 }
 
-func (ssl *SkipStarList) init(ifc interface{}) {
+func (ssl *SkipListStar) init(ifc interface{}) {
 	switch ifc.(type) {
 	case uint8:
 		ssl.ary = 8
@@ -80,12 +80,12 @@ func (ssl *SkipStarList) init(ifc interface{}) {
 	ssl.sl = New(ifc)
 }
 
-func (ssl *SkipStarList) getNormalizedKey(key uint64) uint64 {
+func (ssl *SkipListStar) getNormalizedKey(key uint64) uint64 {
 	key = key/uint64(ssl.ary) + 1
 	return key * uint64(ssl.ary)
 }
 
-func (ssl *SkipStarList) insert(entry Entry) Entry {
+func (ssl *SkipListStar) insert(entry Entry) Entry {
 	key := ssl.getNormalizedKey(entry.Key())
 	eb, ok := ssl.sl.Get(entry.Key())[0].(*entryBundle)
 	if !ok {
@@ -104,7 +104,7 @@ func (ssl *SkipStarList) insert(entry Entry) Entry {
 // existing entry with a matching key will be overwritten.  The returned
 // list of a list of entries that were overwritten, in order.  A nil
 // will be in the in-order position for any non-overwritten entries.
-func (ssl *SkipStarList) Insert(entries ...Entry) Entries {
+func (ssl *SkipListStar) Insert(entries ...Entry) Entries {
 	overwritten := make(Entries, 0, len(entries))
 	for _, e := range entries {
 		overwritten = append(overwritten, ssl.insert(e))
@@ -113,7 +113,7 @@ func (ssl *SkipStarList) Insert(entries ...Entry) Entries {
 	return overwritten
 }
 
-func (ssl *SkipStarList) get(key uint64) Entry {
+func (ssl *SkipListStar) get(key uint64) Entry {
 	normalizedKey := ssl.getNormalizedKey(key)
 	eb, ok := ssl.sl.Get(normalizedKey)[0].(*entryBundle)
 	if ok {
@@ -124,7 +124,7 @@ func (ssl *SkipStarList) get(key uint64) Entry {
 
 // Get will return a list of entries associated with the provided keys.
 // A nil will be returned for any key not found.
-func (ssl *SkipStarList) Get(keys ...uint64) Entries {
+func (ssl *SkipListStar) Get(keys ...uint64) Entries {
 	entries := make(Entries, 0, len(keys))
 	for _, key := range keys {
 		entries = append(entries, ssl.get(key))
@@ -133,7 +133,7 @@ func (ssl *SkipStarList) Get(keys ...uint64) Entries {
 	return entries
 }
 
-func (ssl *SkipStarList) delete(key uint64) Entry {
+func (ssl *SkipListStar) delete(key uint64) Entry {
 	normalizedKey := ssl.getNormalizedKey(key)
 	eb, ok := ssl.sl.Get(normalizedKey)[0].(*entryBundle)
 	if !ok {
@@ -153,7 +153,7 @@ func (ssl *SkipStarList) delete(key uint64) Entry {
 
 // Delete will remove the provided keys from the SkipList* and
 // return a list of entries that were deleted.
-func (ssl *SkipStarList) Delete(keys ...uint64) Entries {
+func (ssl *SkipListStar) Delete(keys ...uint64) Entries {
 	deleted := make(Entries, 0, len(keys))
 	for _, key := range keys {
 		deleted = append(deleted, ssl.delete(key))
@@ -162,7 +162,7 @@ func (ssl *SkipStarList) Delete(keys ...uint64) Entries {
 	return deleted
 }
 
-func (ssl *SkipStarList) iter(key uint64) *starIterator {
+func (ssl *SkipListStar) iter(key uint64) *starIterator {
 	normalizedKey := ssl.getNormalizedKey(key)
 	iter := ssl.sl.Iter(normalizedKey)
 	if !iter.Next() {
@@ -181,20 +181,20 @@ func (ssl *SkipStarList) iter(key uint64) *starIterator {
 
 // Iter will return an iterator that will visit every value
 // equal to or greater than the provided key.
-func (ssl *SkipStarList) Iter(key uint64) Iterator {
+func (ssl *SkipListStar) Iter(key uint64) Iterator {
 	return ssl.iter(key)
 }
 
 // Len returns the number of items in the SkipList*.
-func (ssl *SkipStarList) Len() uint64 {
+func (ssl *SkipListStar) Len() uint64 {
 	return ssl.num
 }
 
-// NewStar will allocate, initialize, and return a new SkipStarList.
+// NewStar will allocate, initialize, and return a new SkipListStar.
 // The Skip* list has an node size defined by the provided interface
 // parameter.  This parameter must be a uint type (uint8, uint16, etc).
-func NewStar(ifc interface{}) *SkipStarList {
-	ssl := &SkipStarList{}
+func NewStar(ifc interface{}) *SkipListStar {
+	ssl := &SkipListStar{}
 	ssl.init(ifc)
 	return ssl
 }

--- a/slice/skip/skipstar.go
+++ b/slice/skip/skipstar.go
@@ -99,6 +99,9 @@ func (ssl *SkipStarList) delete(key uint64) Entry {
 	deleted := eb.entries.delete(key)
 	if deleted != nil {
 		ssl.num--
+		if len(eb.entries) == 0 {
+			ssl.sl.Delete(eb.key)
+		}
 	}
 
 	return deleted

--- a/slice/skip/skipstar.go
+++ b/slice/skip/skipstar.go
@@ -1,3 +1,35 @@
+/*
+Copyright 2014 Workiva, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+SkipList* is a data structure combining elements of both a skiplist
+and the bottom half of a Y-fast trie.  The idea is that you can quickly
+search for a sub branch of the skip list and that this branch can
+fit entirely within cache, thereby improving the performance characteristics
+over a standard skip list.  This also keeps any memcopy operation limited
+to O(log M) where M is the size of the desired universe.
+
+Performance vs standard skip list.
+BenchmarkInsert-8	 2000000	       949 ns/op
+BenchmarkGet-8	 3000000	       516 ns/op
+BenchmarkDelete-8	 3000000	       499 ns/op
+BenchmarkStarInsert-8	 3000000	       453 ns/op
+BenchmarkStarGet-8	 3000000	       524 ns/op
+BenchmarkStarDelete-8	 3000000	       469 ns/op
+*/
 package skip
 
 import "log"
@@ -6,17 +38,23 @@ func init() {
 	log.Printf(`I HATE THIS.`)
 }
 
+// SkipList* implements all methods of a standard skip list but attempts
+// to improve performance by ensuring cache locality.
 type SkipStarList struct {
 	ary uint8
 	num uint64
 	sl  *SkipList
 }
 
+// entryBundle is a helper struct used to define the nodes that
+// can be inserted into the SkipList*.
 type entryBundle struct {
 	key     uint64
 	entries Entries
 }
 
+// Key will return the key associated with this entity bundle.
+// This is required by the Entry interface.
 func (eb *entryBundle) Key() uint64 {
 	return eb.key
 }
@@ -62,6 +100,10 @@ func (ssl *SkipStarList) insert(entry Entry) Entry {
 	return e
 }
 
+// Insert will insert the provded entries into the SkipList*.  Any
+// existing entry with a matching key will be overwritten.  The returned
+// list of a list of entries that were overwritten, in order.  A nil
+// will be in the in-order position for any non-overwritten entries.
 func (ssl *SkipStarList) Insert(entries ...Entry) Entries {
 	overwritten := make(Entries, 0, len(entries))
 	for _, e := range entries {
@@ -80,6 +122,8 @@ func (ssl *SkipStarList) get(key uint64) Entry {
 	return nil
 }
 
+// Get will return a list of entries associated with the provided keys.
+// A nil will be returned for any key not found.
 func (ssl *SkipStarList) Get(keys ...uint64) Entries {
 	entries := make(Entries, 0, len(keys))
 	for _, key := range keys {
@@ -107,6 +151,8 @@ func (ssl *SkipStarList) delete(key uint64) Entry {
 	return deleted
 }
 
+// Delete will remove the provided keys from the SkipList* and
+// return a list of entries that were deleted.
 func (ssl *SkipStarList) Delete(keys ...uint64) Entries {
 	deleted := make(Entries, 0, len(keys))
 	for _, key := range keys {
@@ -133,14 +179,20 @@ func (ssl *SkipStarList) iter(key uint64) *starIterator {
 	}
 }
 
+// Iter will return an iterator that will visit every value
+// equal to or greater than the provided key.
 func (ssl *SkipStarList) Iter(key uint64) Iterator {
 	return ssl.iter(key)
 }
 
+// Len returns the number of items in the SkipList*.
 func (ssl *SkipStarList) Len() uint64 {
 	return ssl.num
 }
 
+// NewStar will allocate, initialize, and return a new SkipStarList.
+// The Skip* list has an node size defined by the provided interface
+// parameter.  This parameter must be a uint type (uint8, uint16, etc).
 func NewStar(ifc interface{}) *SkipStarList {
 	ssl := &SkipStarList{}
 	ssl.init(ifc)

--- a/slice/skip/skipstar.go
+++ b/slice/skip/skipstar.go
@@ -32,12 +32,6 @@ BenchmarkStarDelete-8	 3000000	       469 ns/op
 */
 package skip
 
-import "log"
-
-func init() {
-	log.Printf(`I HATE THIS.`)
-}
-
 // SkipList* implements all methods of a standard skip list but attempts
 // to improve performance by ensuring cache locality.
 type SkipListStar struct {

--- a/slice/skip/skipstar.go
+++ b/slice/skip/skipstar.go
@@ -1,0 +1,145 @@
+package skip
+
+import "log"
+
+func init() {
+	log.Printf(`I HATE THIS.`)
+}
+
+type SkipStarList struct {
+	ary uint8
+	num uint64
+	sl  *SkipList
+}
+
+type entryBundle struct {
+	key     uint64
+	entries Entries
+}
+
+func (eb *entryBundle) Key() uint64 {
+	return eb.key
+}
+
+func newEntryBundle(key uint64, size uint8) *entryBundle {
+	return &entryBundle{
+		key:     key,
+		entries: make(Entries, 0, size),
+	}
+}
+
+func (ssl *SkipStarList) init(ifc interface{}) {
+	switch ifc.(type) {
+	case uint8:
+		ssl.ary = 8
+	case uint16:
+		ssl.ary = 16
+	case uint32:
+		ssl.ary = 32
+	case uint64, uint:
+		ssl.ary = 64
+	}
+	ssl.sl = New(ifc)
+}
+
+func (ssl *SkipStarList) getNormalizedKey(key uint64) uint64 {
+	key = key/uint64(ssl.ary) + 1
+	return key * uint64(ssl.ary)
+}
+
+func (ssl *SkipStarList) insert(entry Entry) Entry {
+	key := ssl.getNormalizedKey(entry.Key())
+	eb, ok := ssl.sl.Get(entry.Key())[0].(*entryBundle)
+	if !ok {
+		eb = newEntryBundle(key, ssl.ary)
+		ssl.sl.Insert(eb)
+	}
+
+	e := eb.entries.insert(entry)
+	if e == nil {
+		ssl.num++
+	}
+	return e
+}
+
+func (ssl *SkipStarList) Insert(entries ...Entry) Entries {
+	overwritten := make(Entries, 0, len(entries))
+	for _, e := range entries {
+		overwritten = append(overwritten, ssl.insert(e))
+	}
+
+	return overwritten
+}
+
+func (ssl *SkipStarList) get(key uint64) Entry {
+	normalizedKey := ssl.getNormalizedKey(key)
+	eb, ok := ssl.sl.Get(normalizedKey)[0].(*entryBundle)
+	if ok {
+		return eb.entries.get(key)
+	}
+	return nil
+}
+
+func (ssl *SkipStarList) Get(keys ...uint64) Entries {
+	entries := make(Entries, 0, len(keys))
+	for _, key := range keys {
+		entries = append(entries, ssl.get(key))
+	}
+
+	return entries
+}
+
+func (ssl *SkipStarList) delete(key uint64) Entry {
+	normalizedKey := ssl.getNormalizedKey(key)
+	eb, ok := ssl.sl.Get(normalizedKey)[0].(*entryBundle)
+	if !ok {
+		return nil
+	}
+
+	deleted := eb.entries.delete(key)
+	if deleted != nil {
+		ssl.num--
+	}
+
+	return deleted
+}
+
+func (ssl *SkipStarList) Delete(keys ...uint64) Entries {
+	deleted := make(Entries, 0, len(keys))
+	for _, key := range keys {
+		deleted = append(deleted, ssl.delete(key))
+	}
+
+	return deleted
+}
+
+func (ssl *SkipStarList) iter(key uint64) *starIterator {
+	normalizedKey := ssl.getNormalizedKey(key)
+	iter := ssl.sl.Iter(normalizedKey)
+	if !iter.Next() {
+		return &starIterator{
+			index: iteratorExhausted,
+		}
+	}
+
+	eb := iter.Value().(*entryBundle)
+	return &starIterator{
+		index:   eb.entries.search(key) - 1,
+		entries: eb.entries,
+		iter:    iter,
+	}
+}
+
+func (ssl *SkipStarList) Iter(key uint64) Iterator {
+	return ssl.iter(key)
+}
+
+func (ssl *SkipStarList) Len() uint64 {
+	return ssl.num
+}
+
+func NewStar(ifc interface{}) *SkipStarList {
+	ssl := &SkipStarList{}
+	ssl.init(ifc)
+	return ssl
+}

--- a/slice/skip/skipstar_test.go
+++ b/slice/skip/skipstar_test.go
@@ -148,7 +148,7 @@ func BenchmarkIterStar(b *testing.B) {
 }
 
 func BenchmarkStarPrepend(b *testing.B) {
-	numItems := 1000
+	numItems := b.N
 	sl := NewStar(uint64(0))
 
 	entries := make(Entries, 0, numItems)

--- a/slice/skip/skipstar_test.go
+++ b/slice/skip/skipstar_test.go
@@ -1,0 +1,102 @@
+package skip
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStarInsert(t *testing.T) {
+	ssl := NewStar(uint8(0))
+
+	e1 := newMockEntry(7)
+	e2 := newMockEntry(10)
+
+	result := ssl.Insert(e1, e2)
+	assert.Equal(t, Entries{nil, nil}, result)
+	assert.Equal(t, Entries{e1}, ssl.Get(7))
+	assert.Equal(t, Entries{e2}, ssl.Get(10))
+	assert.Equal(t, Entries{e1, e2}, ssl.Get(7, 10))
+	assert.Equal(t, Entries{e1, nil}, ssl.Get(7, 13))
+	assert.Equal(t, Entries{e2, nil}, ssl.Get(10, 13))
+	assert.Equal(t, uint64(2), ssl.Len())
+}
+
+func TestStarOverwrite(t *testing.T) {
+	ssl := NewStar(uint8(0))
+	e1 := newMockEntry(7)
+	e2 := newMockEntry(7)
+
+	result := ssl.Insert(e1)
+	assert.Equal(t, Entries{nil}, result)
+	assert.Equal(t, uint64(1), ssl.Len())
+
+	result = ssl.Insert(e2)
+	assert.Equal(t, Entries{e1}, result)
+	assert.Equal(t, uint64(1), ssl.Len())
+}
+
+func TestStarDelete(t *testing.T) {
+	ssl := NewStar(uint8(0))
+	e1 := newMockEntry(5)
+	e2 := newMockEntry(10)
+	ssl.Insert(e1, e2)
+
+	result := ssl.Delete(e1.Key(), e2.Key())
+	assert.Equal(t, Entries{e1, e2}, result)
+	assert.Equal(t, uint64(0), ssl.Len())
+}
+
+func TestStarIter(t *testing.T) {
+	ssl := NewStar(uint8(0))
+
+	iter := ssl.Iter(0)
+	assert.False(t, iter.Next())
+	assert.Nil(t, iter.Value())
+
+	e1 := newMockEntry(5)
+	e2 := newMockEntry(10)
+	ssl.Insert(e1, e2)
+
+	iter = ssl.Iter(0)
+	assert.Equal(t, Entries{e1, e2}, iter.exhaust())
+
+	iter = ssl.Iter(5)
+	assert.Equal(t, Entries{e1, e2}, iter.exhaust())
+
+	iter = ssl.Iter(6)
+	assert.Equal(t, Entries{e2}, iter.exhaust())
+
+	iter = ssl.Iter(10)
+	assert.Equal(t, Entries{e2}, iter.exhaust())
+
+	iter = ssl.Iter(11)
+	assert.Equal(t, Entries{}, iter.exhaust())
+}
+
+func BenchmarkStarInsert(b *testing.B) {
+	numItems := b.N
+	sl := NewStar(uint64(0))
+
+	entries := generateMockEntries(numItems)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		sl.Insert(entries[i%numItems])
+	}
+}
+
+func BenchmarkStarGet(b *testing.B) {
+	numItems := b.N
+	sl := NewStar(uint64(0))
+
+	entries := generateMockEntries(numItems)
+	sl.Insert(entries...)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		sl.Get(entries[i%numItems].Key())
+	}
+}

--- a/slice/skip/skipstar_test.go
+++ b/slice/skip/skipstar_test.go
@@ -114,3 +114,37 @@ func BenchmarkStarDelete(b *testing.B) {
 		sl.Delete(entries[i%numItems].Key())
 	}
 }
+
+func BenchmarkIterStar(b *testing.B) {
+	numItems := b.N
+	sl := NewStar(uint64(0))
+
+	entries := generateMockEntries(numItems)
+	sl.Insert(entries...)
+
+	var iter Iterator
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		for iter = sl.Iter(0); iter.Next(); {
+		}
+	}
+}
+
+func BenchmarkStarPrepend(b *testing.B) {
+	numItems := 1000
+	sl := NewStar(uint64(0))
+
+	entries := make(Entries, 0, numItems)
+	for i := b.N; i < b.N+numItems; i++ {
+		entries = append(entries, newMockEntry(uint64(i)))
+	}
+
+	sl.Insert(entries...)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		sl.Insert(newMockEntry(uint64(i)))
+	}
+}

--- a/slice/skip/skipstar_test.go
+++ b/slice/skip/skipstar_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2014 Workiva, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package skip
 
 import (

--- a/slice/skip/skipstar_test.go
+++ b/slice/skip/skipstar_test.go
@@ -100,3 +100,17 @@ func BenchmarkStarGet(b *testing.B) {
 		sl.Get(entries[i%numItems].Key())
 	}
 }
+
+func BenchmarkStarDelete(b *testing.B) {
+	numItems := b.N
+	sl := NewStar(uint64(0))
+
+	entries := generateMockEntries(numItems)
+	sl.Insert(entries...)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		sl.Delete(entries[i%numItems].Key())
+	}
+}


### PR DESCRIPTION
CODE REVIEW

So this is a Workiva invention.  We combine the typical skip list with the node concept from the bottom half of a y-fast trie.  That is, every element in the skip list has a computable key which is tied to a separate and ordered list with max size O(log M) where M is the size of the universe.  It is hoped that this separate ordered list will have better cache locality than a typical linked list.  It also provides a multithreading algorithm that is easier to implement.  The benchmarks in the included code do show a slight performance improvement, especially on insert, which can probably be improved by playing with the size of the ordered list.

One weakness of the current rangetree is the "prepend" case, or adding a value to a row that has many (millions) of subsequent values in proceeding rows.  I benchmarked the new SkipListStar against the current RT in that situation.

Current: BenchmarkPrepend-8	   50000	     38664 ns/op
SkipList*: BenchmarkStarPrepend-8	 2000000	       608 ns/op

We get quite a boost there.  Future work includes making an immutable version of this.

@beaulyddon-wf @tannermiller-wf @alexandercampbell-wf @rosshendrickson-wf @stevenosborne-wf @tylertreat-wf @ericolson-wf 