### PR TITLE
Fixed issue where we weren't checking entry key on a search operation.

### DIFF
--- a/slice/skip/skip.go
+++ b/slice/skip/skip.go
@@ -122,10 +122,10 @@ func (sl *SkipList) Get(keys ...uint64) Entries {
 	var n *node
 	for _, key := range keys {
 		n = sl.search(key, nil)
-		if n == nil {
-			entries = append(entries, nil)
-		} else {
+		if n != nil && n.entry.Key() == key {
 			entries = append(entries, n.entry)
+		} else {
+			entries = append(entries, nil)
 		}
 	}
 

--- a/slice/skip/skip_test.go
+++ b/slice/skip/skip_test.go
@@ -41,6 +41,7 @@ func TestSimpleInsert(t *testing.T) {
 	assert.Equal(t, Entries{m1}, sl.Get(5))
 	assert.Equal(t, uint64(1), sl.Len())
 	assert.Equal(t, Entries{nil}, overwritten)
+	assert.Equal(t, Entries{nil}, sl.Get(1))
 
 	overwritten = sl.Insert(m2)
 	assert.Equal(t, Entries{m2}, sl.Get(6))

--- a/slice/skip/skipstar.go
+++ b/slice/skip/skipstar.go
@@ -85,7 +85,7 @@ func (ssl *SkipListStar) getNormalizedKey(key uint64) uint64 {
 
 func (ssl *SkipListStar) insert(entry Entry) Entry {
 	key := ssl.getNormalizedKey(entry.Key())
-	eb, ok := ssl.sl.Get(entry.Key())[0].(*entryBundle)
+	eb, ok := ssl.sl.Get(key)[0].(*entryBundle)
 	if !ok {
 		eb = newEntryBundle(key, ssl.ary)
 		ssl.sl.Insert(eb)


### PR DESCRIPTION
CODE REVIEW

Fixes a bug in the skip list code where we would return the next value on a get instead of a matching value.

@alexandercampbell-wf @beaulyddon-wf @rosshendrickson-wf @ericolson-wf @stevenosborne-wf @tylertreat-wf @tannermiller-wf 