### PR TITLE
Avl tree

### DIFF
--- a/tree/avl/avl.go
+++ b/tree/avl/avl.go
@@ -1,0 +1,283 @@
+package avl
+
+import (
+	"log"
+	"math"
+)
+
+func init() {
+	log.Println(`I HATE THIS.`)
+}
+
+type Immutable struct {
+	root   *node
+	number uint64
+	dummy  node
+	cache  nodes
+}
+
+func (immutable *Immutable) copy() *Immutable {
+	var root *node
+	if immutable.root != nil {
+		root = immutable.root.copy()
+	}
+	cp := &Immutable{
+		root:   root,
+		number: immutable.number,
+		dummy:  *newNode(nil),
+	}
+	return cp
+}
+
+func (immutable *Immutable) resetCache() {
+	immutable.cache.reset()
+}
+
+func (immutable *Immutable) resetDummy() {
+	immutable.dummy.children[0], immutable.dummy.children[1] = nil, nil
+	immutable.dummy.balance = 0
+}
+
+func (immutable *Immutable) init() {
+	immutable.dummy = node{
+		children: [2]*node{},
+	}
+	immutable.cache = make(nodes, 64) // this should cover every number in the 64 bit universe
+}
+
+func (immutable *Immutable) get(entry Entry) Entry {
+	n := immutable.root
+	var result int
+	for n != nil {
+		switch result = n.entry.Compare(entry); {
+		case result == 0:
+			return n.entry
+		case result > 0:
+			n = n.children[0]
+		case result < 0:
+			n = n.children[1]
+		}
+	}
+
+	return nil
+}
+
+func (immutable *Immutable) Get(entries ...Entry) Entries {
+	result := make(Entries, 0, len(entries))
+	for _, e := range entries {
+		result = append(result, immutable.get(e))
+	}
+
+	return result
+}
+
+// Len returns the number of items in this immutable.
+func (immutable *Immutable) Len() uint64 {
+	return immutable.number
+}
+
+func (immutable *Immutable) insert(entry Entry) Entry {
+	if immutable.root == nil {
+		immutable.root = newNode(entry)
+		immutable.number++
+		return nil
+	}
+
+	immutable.resetDummy()
+	var (
+		dummy           = immutable.dummy
+		p, s, q         *node
+		dir, normalized int
+		helper          = &dummy
+	)
+
+	// set this AFTER clearing dummy
+	helper.children[1] = immutable.root
+	for s, p = helper.children[1], helper.children[1]; ; {
+		dir = p.entry.Compare(entry)
+
+		normalized = normalizeComparison(dir)
+		if dir > 0 { // go left
+			if p.children[0] != nil {
+				q = p.children[0].copy()
+				p.children[0] = q
+			} else {
+				q = nil
+			}
+		} else if dir < 0 { // go right
+			if p.children[1] != nil {
+				q = p.children[1].copy()
+				p.children[1] = q
+			} else {
+				q = nil
+			}
+		} else { // equality
+			oldEntry := p.entry
+			p.entry = entry
+			return oldEntry
+		}
+		if q == nil {
+			break
+		}
+
+		if q.balance != 0 {
+			helper = p
+			s = q
+		}
+		p = q
+	}
+
+	immutable.number++
+	q = newNode(entry)
+	p.children[normalized] = q
+
+	immutable.root = dummy.children[1]
+	for p = s; p != q; p = p.children[normalized] {
+		normalized = normalizeComparison(p.entry.Compare(entry))
+		if normalized == 0 {
+			p.balance += -1
+		} else {
+			p.balance += 1
+		}
+	}
+
+	q = s
+
+	if math.Abs(float64(s.balance)) > 1 {
+		normalized = normalizeComparison(s.entry.Compare(entry))
+		s = insertBalance(s, normalized)
+	}
+
+	if q == dummy.children[1] {
+		immutable.root = s
+	} else {
+		helper.children[intFromBool(helper.children[1] == q)] = s
+	}
+	return nil
+}
+
+func (immutable *Immutable) Insert(entries ...Entry) (*Immutable, Entries) {
+	if len(entries) == 0 {
+		return immutable, Entries{}
+	}
+
+	overwritten := make(Entries, 0, len(entries))
+	cp := immutable.copy()
+	for _, e := range entries {
+		overwritten = append(overwritten, cp.insert(e))
+	}
+
+	return cp, overwritten
+}
+
+func (immutable *Immutable) remove(entry Entry) Entry {
+	return nil
+}
+
+func insertBalance(root *node, dir int) *node {
+	n := root.children[dir]
+	var bal int8
+	if dir == 0 {
+		bal = -1
+	} else {
+		bal = 1
+	}
+
+	if n.balance == bal {
+		root.balance, n.balance = 0, 0
+		root = rotate(root, takeOpposite(dir))
+	} else { /* n->balance == -bal */
+		adjustBalance(root, dir, int(bal))
+		root = doubleRotate(root, takeOpposite(dir))
+	}
+
+	return root
+}
+
+func removeBalance(root *node, dir int, done *int) *node {
+	n := root.children[takeOpposite(dir)]
+	var bal int8
+	if dir == 0 {
+		bal = -1
+	} else {
+		bal = 1
+	}
+
+	if n.balance == -bal {
+		root.balance, n.balance = 0, 0
+		root = rotate(root, dir)
+	} else if n.balance == bal {
+		adjustBalance(root, takeOpposite(dir), int(-bal))
+		root = doubleRotate(root, dir)
+	} else {
+		root.balance = -bal
+		n.balance = bal
+		root = rotate(root, dir)
+		*done = 1
+	}
+
+	return root
+}
+
+func intFromBool(value bool) int {
+	if value {
+		return 1
+	}
+
+	return 0
+}
+
+func takeOpposite(value int) int {
+	return 1 - value
+}
+
+func adjustBalance(root *node, dir, bal int) {
+	n := root.children[dir]
+	nn := n.children[takeOpposite(dir)]
+
+	if nn.balance == 0 {
+		root.balance, n.balance = 0, 0
+	} else if int(nn.balance) == bal {
+		root.balance = int8(-bal)
+		n.balance = 0
+	} else { /* nn->balance == -bal */
+		root.balance = 0
+		n.balance = int8(bal)
+	}
+	nn.balance = 0
+}
+
+func rotate(parent *node, dir int) *node {
+	otherDir := takeOpposite(dir)
+
+	child := parent.children[otherDir]
+	parent.children[otherDir] = child.children[dir]
+	child.children[dir] = parent
+
+	return child
+}
+
+func doubleRotate(parent *node, dir int) *node {
+	otherDir := takeOpposite(dir)
+
+	parent.children[otherDir] = rotate(parent.children[otherDir], otherDir)
+	return rotate(parent, dir)
+}
+
+func normalizeComparison(i int) int {
+	if i < 0 {
+		return 1
+	}
+
+	if i > 0 {
+		return 0
+	}
+
+	return -1
+}
+
+func NewImmutable() *Immutable {
+	immutable := &Immutable{}
+	immutable.init()
+	return immutable
+}

--- a/tree/avl/avl.go
+++ b/tree/avl/avl.go
@@ -24,6 +24,9 @@ Space: O(n)
 Insert: O(log n)
 Delete: O(log n)
 Get: O(log n)
+
+The immutable version of the AVL tree is obviously going to be slower than
+the mutable version but should offer higher read availability.
 */
 
 package avl

--- a/tree/avl/avl_test.go
+++ b/tree/avl/avl_test.go
@@ -1,0 +1,197 @@
+package avl
+
+import (
+	"log"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func init() {
+	log.Printf(`I HATE THIS.`)
+}
+
+func generateMockEntries(num int) Entries {
+	entries := make(Entries, 0, num)
+	for i := 0; i < num; i++ {
+		entries = append(entries, mockEntry(i))
+	}
+
+	return entries
+}
+
+func TestAVLSimpleInsert(t *testing.T) {
+	i1 := NewImmutable()
+	m1 := mockEntry(5)
+	m2 := mockEntry(10)
+
+	i2, overwritten := i1.Insert(m1, m2)
+	assert.Equal(t, Entries{nil, nil}, overwritten)
+	assert.Equal(t, uint64(2), i2.Len())
+	assert.Equal(t, uint64(0), i1.Len())
+	assert.Equal(t, Entries{nil, nil}, i1.Get(m1, m2))
+	assert.Equal(t, Entries{m1, m2}, i2.Get(m1, m2))
+
+	m3 := mockEntry(1)
+
+	i3, overwritten := i2.Insert(m3)
+	assert.Equal(t, Entries{nil}, overwritten)
+	assert.Equal(t, uint64(3), i3.Len())
+	assert.Equal(t, uint64(2), i2.Len())
+	assert.Equal(t, uint64(0), i1.Len())
+	assert.Equal(t, Entries{m1, m2, m3}, i3.Get(m1, m2, m3))
+}
+
+func TestAVLInsertRightLeaning(t *testing.T) {
+	i1 := NewImmutable()
+	m1 := mockEntry(1)
+	m2 := mockEntry(5)
+	m3 := mockEntry(10)
+
+	i2, overwritten := i1.Insert(m1, m2, m3)
+	assert.Equal(t, Entries{nil, nil, nil}, overwritten)
+	assert.Equal(t, uint64(0), i1.Len())
+	assert.Equal(t, uint64(3), i2.Len())
+	assert.Equal(t, Entries{m1, m2, m3}, i2.Get(m1, m2, m3))
+	assert.Equal(t, Entries{nil, nil, nil}, i1.Get(m1, m2, m3))
+
+	m4 := mockEntry(15)
+	m5 := mockEntry(20)
+
+	i3, overwritten := i2.Insert(m4, m5)
+	assert.Equal(t, Entries{nil, nil}, overwritten)
+	assert.Equal(t, uint64(5), i3.Len())
+	assert.Equal(t, uint64(3), i2.Len())
+	assert.Equal(t, Entries{nil, nil}, i2.Get(m4, m5))
+	assert.Equal(t, Entries{m4, m5}, i3.Get(m4, m5))
+}
+
+func TestAVLInsertRightLeaningDoubleRotation(t *testing.T) {
+	i1 := NewImmutable()
+	m1 := mockEntry(1)
+	m2 := mockEntry(10)
+	m3 := mockEntry(5)
+
+	i2, overwritten := i1.Insert(m1, m2, m3)
+	assert.Equal(t, uint64(3), i2.Len())
+	assert.Equal(t, Entries{nil, nil, nil}, overwritten)
+	assert.Equal(t, Entries{nil, nil, nil}, i1.Get(m1, m2, m3))
+	assert.Equal(t, Entries{m1, m2, m3}, i2.Get(m1, m2, m3))
+
+	m4 := mockEntry(20)
+	m5 := mockEntry(15)
+
+	i3, overwritten := i2.Insert(m4, m5)
+	assert.Equal(t, Entries{nil, nil}, overwritten)
+	assert.Equal(t, uint64(5), i3.Len())
+	assert.Equal(t, uint64(3), i2.Len())
+	assert.Equal(t, Entries{nil, nil}, i2.Get(m4, m5))
+	assert.Equal(t, Entries{m4, m5}, i3.Get(m4, m5))
+}
+
+func TestAVLInsertLeftLeaning(t *testing.T) {
+	i1 := NewImmutable()
+	m1 := mockEntry(20)
+	m2 := mockEntry(15)
+	m3 := mockEntry(10)
+
+	i2, overwritten := i1.Insert(m1, m2, m3)
+	assert.Equal(t, Entries{nil, nil, nil}, overwritten)
+	assert.Equal(t, uint64(0), i1.Len())
+	assert.Equal(t, uint64(3), i2.Len())
+	assert.Equal(t, Entries{nil, nil, nil}, i1.Get(m1, m2, m3))
+	assert.Equal(t, Entries{m1, m2, m3}, i2.Get(m1, m2, m3))
+
+	m4 := mockEntry(5)
+	m5 := mockEntry(1)
+
+	i3, overwritten := i2.Insert(m4, m5)
+	assert.Equal(t, Entries{nil, nil}, overwritten)
+	assert.Equal(t, uint64(3), i2.Len())
+	assert.Equal(t, uint64(5), i3.Len())
+	assert.Equal(t, Entries{nil, nil}, i2.Get(m4, m5))
+	assert.Equal(t, Entries{m4, m5}, i3.Get(m4, m5))
+}
+
+func TestAVLInsertLeftLeaningDoubleRotation(t *testing.T) {
+	i1 := NewImmutable()
+	m1 := mockEntry(20)
+	m2 := mockEntry(10)
+	m3 := mockEntry(15)
+
+	i2, overwritten := i1.Insert(m1, m2, m3)
+	assert.Equal(t, Entries{nil, nil, nil}, overwritten)
+	assert.Equal(t, uint64(0), i1.Len())
+	assert.Equal(t, uint64(3), i2.Len())
+	assert.Equal(t, Entries{nil, nil, nil}, i1.Get(m1, m2, m3))
+	assert.Equal(t, Entries{m1, m2, m3}, i2.Get(m1, m2, m3))
+
+	m4 := mockEntry(1)
+	m5 := mockEntry(5)
+
+	i3, overwritten := i2.Insert(m4, m5)
+	assert.Equal(t, Entries{nil, nil}, overwritten)
+	assert.Equal(t, uint64(3), i2.Len())
+	assert.Equal(t, uint64(5), i3.Len())
+	assert.Equal(t, Entries{nil, nil}, i2.Get(m4, m5))
+	assert.Equal(t, Entries{m4, m5}, i3.Get(m4, m5))
+	assert.Equal(t, Entries{m1, m2, m3}, i3.Get(m1, m2, m3))
+}
+
+func TestAVLInsertOverwrite(t *testing.T) {
+	i1 := NewImmutable()
+	m1 := mockEntry(20)
+	m2 := mockEntry(10)
+	m3 := mockEntry(15)
+
+	i2, _ := i1.Insert(m1, m2, m3)
+	m4 := mockEntry(15)
+
+	i3, overwritten := i2.Insert(m4)
+	assert.Equal(t, Entries{m3}, overwritten)
+	assert.Equal(t, uint64(3), i2.Len())
+	assert.Equal(t, uint64(3), i3.Len())
+	assert.Equal(t, Entries{m4}, i3.Get(m4))
+	assert.Equal(t, Entries{m3}, i2.Get(m3))
+}
+
+func BenchmarkImmutableInsert(b *testing.B) {
+	numItems := b.N
+	sl := NewImmutable()
+
+	entries := generateMockEntries(numItems)
+	sl, _ = sl.Insert(entries...)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		sl, _ = sl.Insert(entries[i%numItems])
+	}
+}
+
+func BenchmarkImmutableGet(b *testing.B) {
+	numItems := b.N
+	sl := NewImmutable()
+
+	entries := generateMockEntries(numItems)
+	sl, _ = sl.Insert(entries...)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		sl.Get(entries[i%numItems])
+	}
+}
+
+func BenchmarkImmutableBulkInsert(b *testing.B) {
+	numItems := b.N
+	sl := NewImmutable()
+
+	entries := generateMockEntries(numItems)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		sl.Insert(entries...)
+	}
+}

--- a/tree/avl/interface.go
+++ b/tree/avl/interface.go
@@ -1,0 +1,10 @@
+package avl
+
+type Entries []Entry
+
+type Entry interface {
+	// Compare should return a value indicating the relationship
+	// of this Entry to the provided Entry.  A -1 means this entry
+	// is less than, 0 means equality, and 1 means greater than.
+	Compare(Entry) int
+}

--- a/tree/avl/interface.go
+++ b/tree/avl/interface.go
@@ -1,7 +1,28 @@
+/*
+Copyright 2014 Workiva, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package avl
 
+// Entries is a list of type Entry.
 type Entries []Entry
 
+// Entry represents all items that can be placed into the AVL tree.
+// They must implement a Compare method that can be used to determine
+// the Entry's correct place in the tree.  Any object can implement
+// Compare.
 type Entry interface {
 	// Compare should return a value indicating the relationship
 	// of this Entry to the provided Entry.  A -1 means this entry

--- a/tree/avl/mock_test.go
+++ b/tree/avl/mock_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2014 Workiva, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package avl
 
 type mockEntry int

--- a/tree/avl/mock_test.go
+++ b/tree/avl/mock_test.go
@@ -1,0 +1,16 @@
+package avl
+
+type mockEntry int
+
+func (me mockEntry) Compare(other Entry) int {
+	otherMe := other.(mockEntry)
+	if me > otherMe {
+		return 1
+	}
+
+	if me < otherMe {
+		return -1
+	}
+
+	return 0
+}

--- a/tree/avl/node.go
+++ b/tree/avl/node.go
@@ -1,0 +1,30 @@
+package avl
+
+type nodes []*node
+
+func (ns nodes) reset() {
+	for i := range ns {
+		ns[i] = nil
+	}
+}
+
+type node struct {
+	balance  int8
+	children [2]*node
+	entry    Entry
+}
+
+func (n *node) copy() *node {
+	return &node{
+		balance:  n.balance,
+		children: [2]*node{n.children[0], n.children[1]},
+		entry:    n.entry,
+	}
+}
+
+func newNode(entry Entry) *node {
+	return &node{
+		entry:    entry,
+		children: [2]*node{},
+	}
+}

--- a/tree/avl/node.go
+++ b/tree/avl/node.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2014 Workiva, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package avl
 
 type nodes []*node
@@ -9,11 +25,13 @@ func (ns nodes) reset() {
 }
 
 type node struct {
-	balance  int8
+	balance  int8 // bounded, |balance| should be <= 1
 	children [2]*node
 	entry    Entry
 }
 
+// copy returns a copy of this node with pointers to the original
+// children.
 func (n *node) copy() *node {
 	return &node{
 		balance:  n.balance,
@@ -22,6 +40,8 @@ func (n *node) copy() *node {
 	}
 }
 
+// newNode returns a new node for the provided entry.  A nil
+// entry is used to represent the dummy node.
 func newNode(entry Entry) *node {
 	return &node{
 		entry:    entry,


### PR DESCRIPTION
CODE REVIEW

This is an immutable AVL tree.  Like clojure, this can serve as the foundation for many types of data structures.  I need to optimize for performance, introduce iterators, add predecessor/ancestor queries, etc.  I also need to add a more comprehensive testing suite.

Benchmarks:
BenchmarkImmutableInsert-8	 1000000	      1949 ns/op
BenchmarkImmutableGet-8	 3000000	       452 ns/op
BenchmarkImmutableBulkInsert-8	    3000	   9220036 ns/op
BenchmarkImmutableDelete-8	 1000000	      2477 ns/op
BenchmarkImmutableBulkDelete-8	   10000	  15048089 ns/op

I think there are some easy ways to get those numbers down, but I wanted to get this up as it's pretty dense.  I'll continue to iterate.

@tannermiller-wf @beaulyddon-wf @ericolson-wf @rosshendrickson-wf @alexandercampbell-wf @tylertreat-wf @stevenosborne-wf 