### PR TITLE
Skiplist index

### DIFF
--- a/btree/palm/tree_test.go
+++ b/btree/palm/tree_test.go
@@ -290,7 +290,6 @@ func BenchmarkReadAndWrites(b *testing.B) {
 	}
 
 	wg.Wait()
-
 }
 
 func BenchmarkBulkAdd(b *testing.B) {

--- a/slice/skip/node.go
+++ b/slice/skip/node.go
@@ -16,6 +16,16 @@ limitations under the License.
 
 package skip
 
+type widths []uint64
+
+func (widths widths) reset() widths {
+	for i := range widths {
+		widths[i] = 0
+	}
+
+	return widths
+}
+
 type nodes []*node
 
 // reset will mark every index in this list of nodes as nil.
@@ -31,6 +41,10 @@ type node struct {
 	// forward denotes the forward pointing pointers in this
 	// node.
 	forward nodes
+	// widths keeps track of the distance between this pointer
+	// and the forward pointers so we can access skip list
+	// values by position in logarithmic time.
+	widths widths
 	// entry is the associated value with this node.
 	entry Entry
 }
@@ -48,5 +62,6 @@ func newNode(entry Entry, maxLevels uint8) *node {
 	return &node{
 		entry:   entry,
 		forward: make(nodes, maxLevels),
+		widths:  make(widths, maxLevels),
 	}
 }

--- a/slice/skip/skip.go
+++ b/slice/skip/skip.go
@@ -78,7 +78,6 @@ func insertNode(sl *SkipList, n *node, entry Entry, pos uint64, cache nodes, pos
 	if nodeLevel > sl.level {
 		for i := sl.level; i < nodeLevel; i++ {
 			cache[i] = sl.head
-			//sl.head.widths[i] = pos
 		}
 		sl.level = nodeLevel
 	}
@@ -211,6 +210,15 @@ func (sl *SkipList) Get(keys ...uint64) Entries {
 	}
 
 	return entries
+}
+
+func (sl *SkipList) GetWithPosition(key uint64) (Entry, uint64) {
+	n, pos := sl.search(key, nil, nil)
+	if n == nil {
+		return nil, 0
+	}
+
+	return n.entry, pos - 1
 }
 
 func (sl *SkipList) ByPosition(position uint64) Entry {

--- a/slice/skip/skip.go
+++ b/slice/skip/skip.go
@@ -225,6 +225,7 @@ func (sl *SkipList) Insert(entries ...Entry) Entries {
 
 func (sl *SkipList) delete(key uint64) Entry {
 	sl.cache.reset()
+	sl.posCache.reset()
 	n, _ := sl.search(key, sl.cache, sl.posCache)
 
 	if n == nil || n.entry.Key() != key {
@@ -235,13 +236,18 @@ func (sl *SkipList) delete(key uint64) Entry {
 
 	for i := uint8(0); i <= sl.level; i++ {
 		if sl.cache[i].forward[i] != n {
-			break
+			if sl.cache[i].forward[i] != nil {
+				sl.cache[i].widths[i]--
+			}
+			continue
 		}
 
+		sl.cache[i].widths[i] += n.widths[i] - 1
 		sl.cache[i].forward[i] = n.forward[i]
 	}
 
 	for sl.level > 0 && sl.head.forward[sl.level] == nil {
+		sl.head.widths[sl.level] = 0
 		sl.level = sl.level - 1
 	}
 

--- a/slice/skip/skip.go
+++ b/slice/skip/skip.go
@@ -26,20 +26,27 @@ Search: O(log n)
 Delete: O(log n)
 Space: O(n)
 
+Recently added is the capability to address, insert, and replace an
+entry by position.  This capability is acheived by saving the width
+of the "gap" between two nodes.  Searching for an item by position is
+very similar to searching by value in that the same basic algorithm is
+used but we are searching for width instead of value.  Because this avoids
+the overhead associated with Golang interfaces, operations by position
+are about twice as fast as operations by value.  Time complexities listed
+below.
+
+SearchByPosition: O(log n)
+InsertByPosition: O(log n)
+
 More information here: http://cglab.ca/~morin/teaching/5408/refs/p90b.pdf
 */
 
 package skip
 
 import (
-	"log"
 	"math/rand"
 	"time"
 )
-
-func init() {
-	log.Printf(`SKIP HATE THIS`)
-}
 
 const p = .5 // the p level defines the probability that a node
 // with a value at level i also has a value at i+1.  This number
@@ -212,6 +219,9 @@ func (sl *SkipList) Get(keys ...uint64) Entries {
 	return entries
 }
 
+// GetWithPosition will retrieve the value with the provided key and
+// return the position of that value within the list.  Returns nil, 0
+// if an associated value could not be found.
 func (sl *SkipList) GetWithPosition(key uint64) (Entry, uint64) {
 	n, pos := sl.search(key, nil, nil)
 	if n == nil {
@@ -221,6 +231,7 @@ func (sl *SkipList) GetWithPosition(key uint64) (Entry, uint64) {
 	return n.entry, pos - 1
 }
 
+// ByPosition returns the entry at the given position.
 func (sl *SkipList) ByPosition(position uint64) Entry {
 	n, _ := sl.searchByPosition(position+1, nil, nil)
 	if n == nil {
@@ -259,8 +270,28 @@ func (sl *SkipList) insertAtPosition(position uint64, entry Entry) {
 	insertNode(sl, n, entry, pos, sl.cache, sl.posCache, true)
 }
 
+// InsertAtPosition will insert the provided entry and the provided position.
+// If position is greater than the length of the skiplist, the entry
+// is appended.  This method bypasses order checks and checks for
+// duplicates so use with caution.
 func (sl *SkipList) InsertAtPosition(position uint64, entry Entry) {
 	sl.insertAtPosition(position, entry)
+}
+
+func (sl *SkipList) replaceAtPosition(position uint64, entry Entry) {
+	n, _ := sl.searchByPosition(position+1, nil, nil)
+	if n == nil {
+		return
+	}
+
+	n.entry = entry
+}
+
+// Replace at position will replace the entry at the provided position
+// with the provided entry.  If the provided position does not exist,
+// this operation is a no-op.
+func (sl *SkipList) ReplaceAtPosition(position uint64, entry Entry) {
+	sl.replaceAtPosition(position, entry)
 }
 
 func (sl *SkipList) delete(key uint64) Entry {

--- a/slice/skip/skip_test.go
+++ b/slice/skip/skip_test.go
@@ -17,10 +17,15 @@ limitations under the License.
 package skip
 
 import (
+	"log"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func init() {
+	log.Printf(`SKIP TEST HATE THIS.`)
+}
 
 func generateMockEntries(num int) Entries {
 	entries := make(Entries, 0, num)
@@ -29,6 +34,27 @@ func generateMockEntries(num int) Entries {
 	}
 
 	return entries
+}
+
+func TestGetByPosition(t *testing.T) {
+	m1 := newMockEntry(5)
+	m2 := newMockEntry(6)
+	sl := New(uint8(0))
+	sl.Insert(m1, m2)
+
+	assert.Equal(t, m1, sl.ByPosition(0))
+	assert.Equal(t, m2, sl.ByPosition(1))
+	assert.Nil(t, sl.ByPosition(2))
+}
+
+func TestGetManyByPosition(t *testing.T) {
+	entries := generateMockEntries(100)
+	sl := New(uint64(0))
+	sl.Insert(entries...)
+
+	for i, e := range entries {
+		assert.Equal(t, e, sl.ByPosition(uint64(i)))
+	}
 }
 
 func TestSimpleInsert(t *testing.T) {

--- a/slice/skip/skip_test.go
+++ b/slice/skip/skip_test.go
@@ -36,6 +36,21 @@ func generateMockEntries(num int) Entries {
 	return entries
 }
 
+func TestInsertByPosition(t *testing.T) {
+	m1 := newMockEntry(5)
+	m2 := newMockEntry(6)
+	m3 := newMockEntry(2)
+	sl := New(uint8(0))
+	sl.InsertAtPosition(2, m1)
+	sl.InsertAtPosition(0, m2)
+	sl.InsertAtPosition(0, m3)
+
+	assert.Equal(t, m3, sl.ByPosition(0))
+	assert.Equal(t, m2, sl.ByPosition(1))
+	assert.Equal(t, m1, sl.ByPosition(2))
+	assert.Nil(t, sl.ByPosition(3))
+}
+
 func TestGetByPosition(t *testing.T) {
 	m1 := newMockEntry(5)
 	m2 := newMockEntry(6)
@@ -48,7 +63,7 @@ func TestGetByPosition(t *testing.T) {
 }
 
 func TestGetManyByPosition(t *testing.T) {
-	entries := generateMockEntries(100)
+	entries := generateMockEntries(10)
 	sl := New(uint64(0))
 	sl.Insert(entries...)
 

--- a/slice/skip/skip_test.go
+++ b/slice/skip/skip_test.go
@@ -18,6 +18,7 @@ package skip
 
 import (
 	"log"
+	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,6 +32,15 @@ func generateMockEntries(num int) Entries {
 	entries := make(Entries, 0, num)
 	for i := uint64(0); i < uint64(num); i++ {
 		entries = append(entries, newMockEntry(i))
+	}
+
+	return entries
+}
+
+func generateRandomMockEntries(num int) Entries {
+	entries := make(Entries, 0, num)
+	for i := 0; i < num; i++ {
+		entries = append(entries, newMockEntry(uint64(rand.Int())))
 	}
 
 	return entries
@@ -60,6 +70,32 @@ func TestGetByPosition(t *testing.T) {
 	assert.Equal(t, m1, sl.ByPosition(0))
 	assert.Equal(t, m2, sl.ByPosition(1))
 	assert.Nil(t, sl.ByPosition(2))
+}
+
+func TestGetWithPosition(t *testing.T) {
+	m1 := newMockEntry(5)
+	m2 := newMockEntry(6)
+	sl := New(uint8(0))
+	sl.Insert(m1, m2)
+
+	e, pos := sl.GetWithPosition(m1.Key())
+	assert.Equal(t, m1, e)
+	assert.Equal(t, uint64(0), pos)
+
+	e, pos = sl.GetWithPosition(m2.Key())
+	assert.Equal(t, m2, e)
+	assert.Equal(t, uint64(1), pos)
+}
+
+func TestInsertRandomGetByPosition(t *testing.T) {
+	entries := generateRandomMockEntries(100)
+	sl := New(uint64(0))
+	sl.Insert(entries...)
+
+	for _, e := range entries {
+		_, pos := sl.GetWithPosition(e.Key())
+		assert.Equal(t, e, sl.ByPosition(pos))
+	}
 }
 
 func TestGetManyByPosition(t *testing.T) {

--- a/slice/skip/skip_test.go
+++ b/slice/skip/skip_test.go
@@ -17,16 +17,11 @@ limitations under the License.
 package skip
 
 import (
-	"log"
 	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
-
-func init() {
-	log.Printf(`SKIP TEST HATE THIS.`)
-}
 
 func generateMockEntries(num int) Entries {
 	entries := make(Entries, 0, num)
@@ -85,6 +80,18 @@ func TestGetWithPosition(t *testing.T) {
 	e, pos = sl.GetWithPosition(m2.Key())
 	assert.Equal(t, m2, e)
 	assert.Equal(t, uint64(1), pos)
+}
+
+func TestReplaceAtPosition(t *testing.T) {
+	m1 := newMockEntry(5)
+	m2 := newMockEntry(6)
+	sl := New(uint8(0))
+
+	sl.Insert(m1, m2)
+	m3 := newMockEntry(9)
+	sl.ReplaceAtPosition(0, m3)
+	assert.Equal(t, m3, sl.ByPosition(0))
+	assert.Equal(t, m2, sl.ByPosition(1))
 }
 
 func TestInsertRandomGetByPosition(t *testing.T) {


### PR DESCRIPTION
CODE REVIEW

Sorry this one took so long, hung up in patent meetings :(.  This code allows us to index values in the skiplist by position.  This isn't a constant time operation and is performed in O(log n) as we apply an algorithm that's very similar to the index by value.  Indexing by position does, however, end up being about twice as fast as in doing so we get to compare two uint64s instead of calling an interface method.  This will continue to be the case as long as Golang doesn't support generics.  The basic algorithm is described here:

http://cglab.ca/~morin/teaching/5408/refs/p90b.pdf

But slightly modified by us as we support both position and value indices.  I still need to add the skiplist split logic which will allow us to split at a position and then skiplists can be dropped into the PALM tree nodes for a potential performance improvement there.

@alexandercampbell-wf @tannermiller-wf @beaulyddon-wf @rosshendrickson-wf @stevenosborne-wf @tylertreat-wf @ericolson-wf 