### PR TITLE
Added split functionality to skiplist for use in B-tree nodes.

### DIFF
--- a/slice/skip/skip.go
+++ b/slice/skip/skip.go
@@ -115,6 +115,32 @@ func insertNode(sl *SkipList, n *node, entry Entry, pos uint64, cache nodes, pos
 	return nil
 }
 
+func splitAt(sl *SkipList, index uint64) (*SkipList, *SkipList) {
+	right := &SkipList{}
+	right.maxLevel = sl.maxLevel
+	right.cache = make(nodes, sl.maxLevel)
+	right.posCache = make(widths, sl.maxLevel)
+	right.head = newNode(nil, sl.maxLevel)
+	sl.searchByPosition(index, sl.cache, sl.posCache) // populate the cache that needs updating
+
+	for i := uint8(0); i <= sl.level; i++ {
+		right.head.forward[i] = sl.cache[i].forward[i]
+		if sl.cache[i].widths[i] != 0 {
+			right.head.widths[i] = sl.cache[i].widths[i] - (index - sl.posCache[i])
+		}
+		sl.cache[i].widths[i] = 0
+		sl.cache[i].forward[i] = nil
+	}
+
+	right.num = sl.num - index
+	sl.num = sl.num - right.num
+
+	sl.resetMaxLevel()
+	right.resetMaxLevel()
+
+	return sl, right
+}
+
 // Skip list is a datastructure that probabalistically determines
 // relationships between nodes.  This results in a structure
 // that performs similarly to a BST but is much easier to build
@@ -170,6 +196,12 @@ func (sl *SkipList) search(key uint64, update nodes, widths widths) (*node, uint
 	}
 
 	return n.forward[0], pos + 1
+}
+
+func (sl *SkipList) resetMaxLevel() {
+	for sl.head.forward[sl.level] == nil && sl.level > 1 {
+		sl.level--
+	}
 }
 
 func (sl *SkipList) searchByPosition(position uint64, update nodes, widths widths) (*node, uint64) {
@@ -360,6 +392,14 @@ func (sl *SkipList) iter(key uint64) *iterator {
 // the key provided.
 func (sl *SkipList) Iter(key uint64) Iterator {
 	return sl.iter(key)
+}
+
+func (sl *SkipList) SplitAt(index uint64) (*SkipList, *SkipList) {
+	index++ // 0-index offset
+	if index >= sl.num {
+		return sl, nil
+	}
+	return splitAt(sl, index)
 }
 
 // New will allocate, initialize, and return a new skiplist.

--- a/slice/skip/skip.go
+++ b/slice/skip/skip.go
@@ -394,6 +394,12 @@ func (sl *SkipList) Iter(key uint64) Iterator {
 	return sl.iter(key)
 }
 
+// SplitAt will split the current skiplist into two lists.  The first
+// skiplist returned is the "left" list and the second is the "right."
+// The index defines the last item in the left list.  If index is greater
+// then the length of this list, only the left skiplist is returned
+// and the right will be nil.  This is a mutable operation and modifies
+// the content of this list.
 func (sl *SkipList) SplitAt(index uint64) (*SkipList, *SkipList) {
 	index++ // 0-index offset
 	if index >= sl.num {

--- a/slice/skip/skip_test.go
+++ b/slice/skip/skip_test.go
@@ -67,6 +67,81 @@ func TestGetByPosition(t *testing.T) {
 	assert.Nil(t, sl.ByPosition(2))
 }
 
+func TestSplitAt(t *testing.T) {
+	m1 := newMockEntry(3)
+	m2 := newMockEntry(5)
+	m3 := newMockEntry(7)
+	sl := New(uint8(0))
+	sl.Insert(m1, m2, m3)
+
+	left, right := sl.SplitAt(1)
+	assert.Equal(t, uint64(2), left.Len())
+	assert.Equal(t, uint64(1), right.Len())
+	assert.Equal(t, Entries{m1, m2, nil}, left.Get(m1.Key(), m2.Key(), m3.Key()))
+	assert.Equal(t, Entries{nil, nil, m3}, right.Get(m1.Key(), m2.Key(), m3.Key()))
+	assert.Equal(t, m1, left.ByPosition(0))
+	assert.Equal(t, m2, left.ByPosition(1))
+	assert.Equal(t, m3, right.ByPosition(0))
+	assert.Equal(t, nil, left.ByPosition(2))
+	assert.Equal(t, nil, right.ByPosition(1))
+}
+
+func TestSplitLargeSkipList(t *testing.T) {
+	entries := generateMockEntries(100)
+	leftEntries := entries[:50]
+	rightEntries := entries[50:]
+	sl := New(uint64(0))
+	sl.Insert(entries...)
+
+	left, right := sl.SplitAt(49)
+	assert.Equal(t, uint64(50), left.Len())
+	for _, le := range leftEntries {
+		result, index := left.GetWithPosition(le.Key())
+		assert.Equal(t, le, result)
+		assert.Equal(t, le, left.ByPosition(index))
+	}
+
+	assert.Equal(t, uint64(50), right.Len())
+	for _, re := range rightEntries {
+		result, index := right.GetWithPosition(re.Key())
+		assert.Equal(t, re, result)
+		assert.Equal(t, re, right.ByPosition(index))
+	}
+}
+
+func TestSplitLargeSkipListOddNumber(t *testing.T) {
+	entries := generateMockEntries(99)
+	leftEntries := entries[:50]
+	rightEntries := entries[50:]
+	sl := New(uint64(0))
+	sl.Insert(entries...)
+
+	left, right := sl.SplitAt(49)
+	assert.Equal(t, uint64(50), left.Len())
+	for _, le := range leftEntries {
+		result, index := left.GetWithPosition(le.Key())
+		assert.Equal(t, le, result)
+		assert.Equal(t, le, left.ByPosition(index))
+	}
+
+	assert.Equal(t, uint64(49), right.Len())
+	for _, re := range rightEntries {
+		result, index := right.GetWithPosition(re.Key())
+		assert.Equal(t, re, result)
+		assert.Equal(t, re, right.ByPosition(index))
+	}
+}
+
+func TestSplitAtSkipListLength(t *testing.T) {
+	entries := generateMockEntries(5)
+	sl := New(uint64(0))
+	sl.Insert(entries...)
+
+	left, right := sl.SplitAt(4)
+	assert.Equal(t, sl, left)
+	assert.Nil(t, right)
+}
+
 func TestGetWithPosition(t *testing.T) {
 	m1 := newMockEntry(5)
 	m2 := newMockEntry(6)


### PR DESCRIPTION
CODE REVIEW

Needed this functionality so skiplists could be used in B-tree nodes.  Should eliminate any memmove currently required by the arrays.

@alexandercampbell-wf @beaulyddon-wf @rosshendrickson-wf @tannermiller-wf @ericolson-wf @stevenosborne-wf @tylertreat-wf 