### PR TITLE
Tiny Set optimizations

### DIFF
--- a/set/dict.go
+++ b/set/dict.go
@@ -59,9 +59,11 @@ func (set *Set) Remove(items ...interface{}) {
 // Exists returns a bool indicating if the given item exists in the set.
 func (set *Set) Exists(item interface{}) bool {
 	set.lock.RLock()
-	defer set.lock.RUnlock()
 
 	_, ok := set.items[item]
+
+	set.lock.RUnlock()
+
 	return ok
 }
 
@@ -84,17 +86,21 @@ func (set *Set) Flatten() []interface{} {
 // Len returns the number of items in the set.
 func (set *Set) Len() int64 {
 	set.lock.RLock()
-	defer set.lock.RUnlock()
 
-	return int64(len(set.items))
+	size := int64(len(set.items))
+
+	set.lock.RUnlock()
+
+	return size
 }
 
 // Clear will remove all items from the set.
 func (set *Set) Clear() {
 	set.lock.Lock()
-	defer set.lock.Unlock()
 
 	set.items = map[interface{}]struct{}{}
+
+	set.lock.Unlock()
 }
 
 // All returns a bool indicating if all of the supplied items exist in the set.

--- a/set/dict.go
+++ b/set/dict.go
@@ -29,7 +29,7 @@ var pool = sync.Pool{}
 
 // Set is an implementation of ISet using the builtin map type. Set is threadsafe.
 type Set struct {
-	items     map[interface{}]bool
+	items     map[interface{}]struct{}
 	lock      sync.RWMutex
 	flattened []interface{}
 }
@@ -41,7 +41,7 @@ func (set *Set) Add(items ...interface{}) {
 
 	set.flattened = nil
 	for _, item := range items {
-		set.items[item] = true
+		set.items[item] = struct{}{}
 	}
 }
 
@@ -94,7 +94,7 @@ func (set *Set) Clear() {
 	set.lock.Lock()
 	defer set.lock.Unlock()
 
-	set.items = map[interface{}]bool{}
+	set.items = map[interface{}]struct{}{}
 }
 
 // All returns a bool indicating if all of the supplied items exist in the set.
@@ -134,7 +134,7 @@ func (set *Set) Dispose() {
 func New(items ...interface{}) *Set {
 	set := pool.Get().(*Set)
 	for _, item := range items {
-		set.items[item] = true
+		set.items[item] = struct{}{}
 	}
 
 	return set
@@ -143,7 +143,7 @@ func New(items ...interface{}) *Set {
 func init() {
 	pool.New = func() interface{} {
 		return &Set{
-			items: make(map[interface{}]bool, 10),
+			items: make(map[interface{}]struct{}, 10),
 		}
 	}
 }

--- a/set/dict_test.go
+++ b/set/dict_test.go
@@ -176,3 +176,39 @@ func BenchmarkFlatten(b *testing.B) {
 		set.Flatten()
 	}
 }
+
+func BenchmarkLen(b *testing.B) {
+	set := New()
+	for i := 0; i < 50; i++ {
+		item := strconv.Itoa(i)
+		set.Add(item)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		set.Len()
+	}
+}
+
+func BenchmarkExists(b *testing.B) {
+	set := New()
+	set.Add(1)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		set.Exists(1)
+	}
+}
+
+func BenchmarkClear(b *testing.B) {
+	set := New()
+	for i := 0; i < 50; i++ {
+		item := strconv.Itoa(i)
+		set.Add(item)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		set.Clear()
+	}
+}

--- a/set/dict_test.go
+++ b/set/dict_test.go
@@ -201,6 +201,7 @@ func BenchmarkExists(b *testing.B) {
 }
 
 func BenchmarkClear(b *testing.B) {
+	set := New()
 	for i := 0; i < b.N; i++ {
 		set.Clear()
 	}

--- a/set/dict_test.go
+++ b/set/dict_test.go
@@ -201,13 +201,6 @@ func BenchmarkExists(b *testing.B) {
 }
 
 func BenchmarkClear(b *testing.B) {
-	set := New()
-	for i := 0; i < 50; i++ {
-		item := strconv.Itoa(i)
-		set.Add(item)
-	}
-
-	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		set.Clear()
 	}


### PR DESCRIPTION
1. `bool` is replaced with `struct{}` to save some memory in large sets
1. Use direct call of (R)Unlock in really plain simple methods like `Exists`, `Len`, `Clear` to speedup Set

with `defer()`
```
BenchmarkLen	50000000	        52.8 ns/op
BenchmarkExists	20000000	        93.4 ns/op
BenchmarkClear	10000000	       215 ns/op
```
without `defer()`
```
BenchmarkLen	100000000	        21.9 ns/op
BenchmarkExists	50000000	        51.5 ns/op
BenchmarkClear	10000000	       167 ns/op
```