### PR TITLE
Palm buffer

### DIFF
--- a/btree/palm/action.go
+++ b/btree/palm/action.go
@@ -17,16 +17,10 @@ limitations under the License.
 package palm
 
 import (
-	//"log"
 	"runtime"
 	"sync"
 	"sync/atomic"
-
-	"github.com/Workiva/go-datastructures/queue"
 )
-
-type gets Keys
-type adds Keys
 
 type actions []action
 
@@ -110,41 +104,6 @@ func newInsertAction(keys Keys) *insertAction {
 	}
 	ia.completer.Add(1)
 	return ia
-}
-
-func executeInParallel(q *queue.RingBuffer, fn func(interface{})) {
-	if q == nil {
-		return
-	}
-
-	todo, done := q.Len(), uint64(0)
-	if todo == 0 {
-		return
-	}
-
-	goRoutines := minUint64(todo, uint64(runtime.NumCPU()-1))
-
-	var wg sync.WaitGroup
-	wg.Add(1)
-
-	for i := uint64(0); i < goRoutines; i++ {
-		go func() {
-			for {
-				ifc, err := q.Get()
-				if err != nil {
-					return
-				}
-				fn(ifc)
-
-				if atomic.AddUint64(&done, 1) == todo {
-					wg.Done()
-					break
-				}
-			}
-		}()
-	}
-	wg.Wait()
-	q.Dispose()
 }
 
 func minUint64(choices ...uint64) uint64 {

--- a/btree/palm/interface.go
+++ b/btree/palm/interface.go
@@ -30,11 +30,13 @@ bulk operations.
 
 Benchmarks:
 
-BenchmarkReadAndWrites-8	   		  1000	   1543648 ns/op
-BenchmarkBulkAdd-8	    			  1000	   1705673 ns/op
-BenchmarkBulkAddToExisting-8	       100	  70056512 ns/op
-BenchmarkGet-8	  					100000	     17128 ns/op
-BenchmarkBulkGet-8	    			  3000	    507249 ns/op
+BenchmarkReadAndWrites-8	    			2000	    984200 ns/op
+BenchmarkSimultaneousReadsAndWrites-8	     300	   5578649 ns/op
+BenchmarkBulkAdd-8	     					 100	  10271157 ns/op
+BenchmarkAdd-8	  						  100000	     24876 ns/op
+BenchmarkBulkAddToExisting-8	      		  20	  59432530 ns/op
+BenchmarkGet-8	 						 2000000	       780 ns/op
+BenchmarkBulkGet-8	    					3000	    353824 ns/op
 */
 package palm
 

--- a/btree/palm/node.go
+++ b/btree/palm/node.go
@@ -124,6 +124,15 @@ func (ks *keys) insertAt(i uint64, k Key) {
 	ks.list.InsertAtPosition(i, k.(skip.Entry))
 }
 
+func (ks *keys) withPosition(k Key) (Key, uint64) {
+	key, pos := ks.list.GetWithPosition(k)
+	if key == nil {
+		return nil, pos
+	}
+
+	return key.(Key), pos
+}
+
 func newKeys() *keys {
 	return &keys{
 		list: skip.New(uint64(0)),

--- a/btree/palm/tree.go
+++ b/btree/palm/tree.go
@@ -21,7 +21,6 @@ import (
 	"runtime"
 	"sync"
 	"sync/atomic"
-	//"time"
 
 	"github.com/Workiva/go-datastructures/queue"
 )

--- a/btree/palm/tree_test.go
+++ b/btree/palm/tree_test.go
@@ -22,7 +22,6 @@ import (
 	"os"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -325,21 +324,16 @@ func BenchmarkBulkAdd(b *testing.B) {
 	}
 }
 
-func TestBulkAdd(t *testing.T) {
-	numItems := 10000
-	N := 1
-	keys := generateKeys(numItems)
-	keySet := make([]Keys, 0, N)
-	for i := 0; i < N; i++ {
-		cp := make(Keys, len(keys))
-		copy(cp, keys)
-		keySet = append(keySet, cp)
-	}
+func BenchmarkAdd(b *testing.B) {
+	numItems := 500
+	keys := generateRandomKeys(numItems)
+	tree := newTree(32, 1024)
+	tree.Insert(keys...)
 
-	for i := 0; i < N; i++ {
-		tree := newTree(8, 1024)
-		tree.Insert(keySet[i]...)
-		tree.Dispose()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		tree.Insert(keys[i%numItems])
 	}
 }
 
@@ -360,11 +354,10 @@ func BenchmarkBulkAddToExisting(b *testing.B) {
 }
 
 func BenchmarkGet(b *testing.B) {
-	numItems := 100000
+	numItems := 10000
 	keys := generateRandomKeys(numItems)
 	tree := newTree(32, 1024)
 	tree.Insert(keys...)
-	time.Sleep(2 * time.Second)
 
 	b.ResetTimer()
 

--- a/btree/palm/tree_test.go
+++ b/btree/palm/tree_test.go
@@ -261,7 +261,7 @@ func TestSimultaneousReadsAndWrites(t *testing.T) {
 	numLoops := 3
 	keys := make([]Keys, 0, numLoops)
 	for i := 0; i < numLoops; i++ {
-		keys = append(keys, generateRandomKeys(1000))
+		keys = append(keys, generateRandomKeys(10))
 	}
 
 	tree := newTree(16, 16)

--- a/btree/palm/tree_test.go
+++ b/btree/palm/tree_test.go
@@ -113,7 +113,7 @@ func TestSimpleInsert(t *testing.T) {
 	m1 := mockKey(1)
 
 	tree.Insert(m1)
-	//assert.Equal(t, Keys{m1}, tree.Get(m1))
+	assert.Equal(t, Keys{m1}, tree.Get(m1))
 	assert.Equal(t, uint64(1), tree.Len())
 	checkTree(t, tree)
 }

--- a/queue/ring_test.go
+++ b/queue/ring_test.go
@@ -192,11 +192,9 @@ func TestDisposeOnGet(t *testing.T) {
 	}
 
 	spunUp.Wait()
-
 	rb.Dispose()
 
 	wg.Wait()
-
 	assert.True(t, rb.IsDisposed())
 }
 


### PR DESCRIPTION
CODE REVIEW

Refactor to integrate ring buffer plus adds some fast paths.  Also modifies how we multithread key lookups.  Some performance improvements, but still some ways to go.

BenchmarkReadAndWrites-8	    2000	    984200 ns/op
BenchmarkSimultaneousReadsAndWrites-8	     300	   5578649 ns/op
BenchmarkBulkAdd-8	     100	  10271157 ns/op
BenchmarkAdd-8	  100000	     24876 ns/op
BenchmarkBulkAddToExisting-8	      20	  59432530 ns/op
BenchmarkGet-8	 2000000	       780 ns/op
BenchmarkBulkGet-8	    3000	    353824 ns/op

@alexandercampbell-wf @beaulyddon-wf @tannermiller-wf @ericolson-wf @rosshendrickson-wf @stevenosborne-wf @tylertreat-wf 
