### PR TITLE
Back to slices

### DIFF
--- a/btree/palm/interface.go
+++ b/btree/palm/interface.go
@@ -30,13 +30,13 @@ bulk operations.
 
 Benchmarks:
 
-BenchmarkReadAndWrites-8	    			2000	    906194 ns/op
-BenchmarkSimultaneousReadsAndWrites-8	     300	   5344702 ns/op
-BenchmarkBulkAdd-8	     					 200	   7586705 ns/op
-BenchmarkAdd-8	  						  100000	     17753 ns/op
-BenchmarkBulkAddToExisting-8	      		  30	  51230180 ns/op
-BenchmarkGet-8	 						 2000000	       724 ns/op
-BenchmarkBulkGet-8	    					5000	    284905 ns/op
+BenchmarkReadAndWrites-8	    			2000	    943051 ns/op
+BenchmarkSimultaneousReadsAndWrites-8	     300	   4354136 ns/op
+BenchmarkBulkAdd-8	     					 200	   5617104 ns/op
+BenchmarkAdd-8	  						  200000	      8976 ns/op
+BenchmarkBulkAddToExisting-8	     	     100	  20682933 ns/op
+BenchmarkGet-8	 						 2000000	       629 ns/op
+BenchmarkBulkGet-8	    					5000	    217915 ns/op
 
 */
 package palm

--- a/btree/palm/node.go
+++ b/btree/palm/node.go
@@ -127,11 +127,11 @@ func (ks *keys) search(key common.Comparator) uint64 {
 	return uint64(i)
 }
 
-func (ks *keys) insert(key common.Comparator) common.Comparator {
+func (ks *keys) insert(key common.Comparator) (common.Comparator, uint64) {
 	i := ks.search(key)
 	if i == uint64(len(ks.list)) {
 		ks.list = append(ks.list, key)
-		return nil
+		return nil, i
 	}
 
 	old := ks.list[i]
@@ -141,7 +141,7 @@ func (ks *keys) insert(key common.Comparator) common.Comparator {
 		ks.insertAt(i, key)
 	}
 
-	return old
+	return old, i
 }
 
 func (ks *keys) last() common.Comparator {

--- a/btree/palm/node.go
+++ b/btree/palm/node.go
@@ -43,11 +43,8 @@ func (ns *nodes) push(n *node) {
 
 func (ns *nodes) splitAt(i, capacity uint64) (*nodes, *nodes) {
 	i++
-	//log.Printf(`SPLITTING AT: %+v`, i)
-
 	right := make([]*node, uint64(len(ns.list))-i, capacity)
 	copy(right, ns.list[i:])
-	//log.Printf(`NS.LIST: %+v, RIGHT: %+v`, ns.list, right)
 	for j := i; j < uint64(len(ns.list)); j++ {
 		ns.list[j] = nil
 	}

--- a/btree/palm/tree.go
+++ b/btree/palm/tree.go
@@ -99,7 +99,7 @@ func (ptree *ptree) init(bufferSize, ary uint64) {
 	ptree.bufferSize = bufferSize
 	ptree.ary = ary
 	ptree.cache = make([]interface{}, 0, bufferSize)
-	ptree.root = newNode(true, newKeys(), newNodes(ary))
+	ptree.root = newNode(true, newKeys(ary), newNodes(ary))
 	ptree.actions = queue.NewRingBuffer(ptree.bufferSize)
 }
 
@@ -267,7 +267,9 @@ func (ptree *ptree) recursiveSplit(n, parent, left *node, nodes *[]*node, keys *
 		return
 	}
 
-	key, l, r := n.split()
+	i := n.keys.len() / 2
+
+	key, l, r := n.split(i)
 	if left != nil {
 		left.right = l
 	}
@@ -296,7 +298,7 @@ func (ptree *ptree) recursiveAdd(layer map[*node][]*recursiveBuild, setRoot bool
 	var write sync.Mutex
 	layer = make(map[*node][]*recursiveBuild, len(layer))
 	dummyRoot := &node{
-		keys:  newKeys(),
+		keys:  newKeys(ptree.ary),
 		nodes: newNodes(ptree.ary),
 	}
 	executeInterfacesInParallel(ifs, func(ifc interface{}) {
@@ -365,7 +367,7 @@ func (ptree *ptree) runAdds(addOperations map[*node]common.Comparators) {
 	var dummyRoot *node
 	if needRoot {
 		dummyRoot = &node{
-			keys:  newKeys(),
+			keys:  newKeys(ptree.ary),
 			nodes: newNodes(ptree.ary),
 		}
 	}

--- a/btree/palm/tree.go
+++ b/btree/palm/tree.go
@@ -262,7 +262,7 @@ func (ptree *ptree) fetchKeys(xns []interface{}) (map[*node]common.Comparators, 
 	return writeOperations, toComplete
 }
 
-func (ptree *ptree) recursiveSplit(n, parent, left *node, nodes *[]*node, keys *common.Comparators) {
+func (ptree *ptree) splitNode(n, parent *node, nodes *[]*node, keys *common.Comparators) {
 	if !n.needsSplit(ptree.ary) {
 		return
 	}
@@ -338,7 +338,7 @@ func (ptree *ptree) recursiveAdd(layer map[*node][]*recursiveBuild, setRoot bool
 		if n.needsSplit(ptree.ary) {
 			keys := make(common.Comparators, 0, n.keys.len())
 			nodes := make([]*node, 0, n.nodes.len())
-			ptree.recursiveSplit(n, parent, nil, &nodes, &keys)
+			ptree.splitNode(n, parent, &nodes, &keys)
 			write.Lock()
 			layer[parent] = append(
 				layer[parent], &recursiveBuild{keys: keys, nodes: nodes, parent: parent},
@@ -397,7 +397,7 @@ func (ptree *ptree) runAdds(addOperations map[*node]common.Comparators) {
 		if n.needsSplit(ptree.ary) {
 			keys := make(common.Comparators, 0, n.keys.len())
 			nodes := make([]*node, 0, n.nodes.len())
-			ptree.recursiveSplit(n, parent, nil, &nodes, &keys)
+			ptree.splitNode(n, parent, &nodes, &keys)
 			write.Lock()
 			nextLayer[parent] = append(
 				nextLayer[parent], &recursiveBuild{keys: keys, nodes: nodes, parent: parent},

--- a/btree/palm/tree.go
+++ b/btree/palm/tree.go
@@ -267,18 +267,18 @@ func (ptree *ptree) recursiveSplit(n, parent, left *node, nodes *[]*node, keys *
 		return
 	}
 
-	i := n.keys.len() / 2
+	length := n.keys.len()
+	splitAt := ptree.ary - 1
 
-	key, l, r := n.split(i)
-	if left != nil {
-		left.right = l
+	for i := splitAt; i < length; i += splitAt {
+		offset := length - i
+		k, left, right := n.split(offset)
+		left.right = right
+		*keys = append(*keys, k)
+		*nodes = append(*nodes, left, right)
+		left.parent = parent
+		right.parent = parent
 	}
-	l.parent = parent
-	r.parent = parent
-	*keys = append(*keys, key)
-	*nodes = append(*nodes, l, r)
-	ptree.recursiveSplit(l, parent, left, nodes, keys)
-	ptree.recursiveSplit(r, parent, l, nodes, keys)
 }
 
 func (ptree *ptree) recursiveAdd(layer map[*node][]*recursiveBuild, setRoot bool) {

--- a/btree/palm/tree.go
+++ b/btree/palm/tree.go
@@ -331,7 +331,7 @@ func (ptree *ptree) recursiveAdd(layer map[*node][]*keyBundle, setRoot bool) {
 
 		for _, kb := range kbs {
 			if n.keys.len() == 0 {
-				oldKey := n.keys.insert(kb.key)
+				oldKey, _ := n.keys.insert(kb.key)
 				if n.isLeaf && oldKey == nil {
 					atomic.AddUint64(&ptree.number, 1)
 				}
@@ -342,12 +342,11 @@ func (ptree *ptree) recursiveAdd(layer map[*node][]*keyBundle, setRoot bool) {
 				continue
 			}
 
-			oldKey := n.keys.insert(kb.key)
+			oldKey, index := n.keys.insert(kb.key)
 			if n.isLeaf && oldKey == nil {
 				atomic.AddUint64(&ptree.number, 1)
 			}
 			if kb.left != nil {
-				index := n.search(kb.key)
 				n.nodes.replaceAt(index, kb.left)
 				n.nodes.insertAt(index+1, kb.right)
 			}

--- a/btree/palm/tree.go
+++ b/btree/palm/tree.go
@@ -272,7 +272,7 @@ func (ptree *ptree) splitNode(n, parent *node, nodes *[]*node, keys *common.Comp
 
 	for i := splitAt; i < length; i += splitAt {
 		offset := length - i
-		k, left, right := n.split(offset)
+		k, left, right := n.split(offset, ptree.ary)
 		left.right = right
 		*keys = append(*keys, k)
 		*nodes = append(*nodes, left, right)

--- a/btree/palm/tree.go
+++ b/btree/palm/tree.go
@@ -292,15 +292,23 @@ func (ptree *ptree) recursiveAdd(layer map[*node][]*recursiveBuild, setRoot bool
 
 	ifs := make(interfaces, 0, len(layer))
 	for _, rbs := range layer {
+		if rbs[0].parent.parent == nil {
+			setRoot = true
+		}
 		ifs = append(ifs, rbs)
+	}
+
+	var dummyRoot *node
+	if setRoot {
+		dummyRoot = &node{
+			keys:  newKeys(ptree.ary),
+			nodes: newNodes(ptree.ary),
+		}
 	}
 
 	var write sync.Mutex
 	layer = make(map[*node][]*recursiveBuild, len(layer))
-	dummyRoot := &node{
-		keys:  newKeys(ptree.ary),
-		nodes: newNodes(ptree.ary),
-	}
+
 	executeInterfacesInParallel(ifs, func(ifc interface{}) {
 		rbs := ifc.([]*recursiveBuild)
 

--- a/btree/palm/tree_test.go
+++ b/btree/palm/tree_test.go
@@ -55,7 +55,7 @@ func checkNode(t testing.TB, n *node) bool {
 
 	i := uint64(0)
 	for iter := n.keys.list.IterAtPosition(0); iter.Next(); {
-		nd := n.nodes.list.ByPosition(i).(*node)
+		nd := n.nodes.list[i]
 		k := iter.Value()
 		if !assert.NotNil(t, nd) {
 			return false
@@ -74,8 +74,7 @@ func checkNode(t testing.TB, n *node) bool {
 		t.Logf(`m: %+v, %p, n.nodes[len(n.nodes)-1].key(): %+v, n.keys.last(): %+v`, n, n, nd, k)
 		return false
 	}
-	for iter := n.nodes.list.IterAtPosition(0); iter.Next(); {
-		child := iter.Value().(*node)
+	for _, child := range n.nodes.list {
 		if !assert.NotNil(t, child) {
 			return false
 		}
@@ -293,7 +292,7 @@ func BenchmarkReadAndWrites(b *testing.B) {
 		keys = append(keys, generateRandomKeys(numItems))
 	}
 
-	tree := newTree(16, 16)
+	tree := newTree(16, 8)
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
@@ -310,7 +309,7 @@ func BenchmarkSimultaneousReadsAndWrites(b *testing.B) {
 		keys = append(keys, generateRandomKeys(numItems))
 	}
 
-	tree := newTree(16, 16)
+	tree := newTree(16, 8)
 	var wg sync.WaitGroup
 	b.ResetTimer()
 
@@ -335,7 +334,7 @@ func BenchmarkBulkAdd(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		tree := newTree(8, 5000)
+		tree := newTree(8, 8)
 		tree.Insert(keys...)
 		tree.Dispose()
 	}
@@ -344,7 +343,7 @@ func BenchmarkBulkAdd(b *testing.B) {
 func BenchmarkAdd(b *testing.B) {
 	numItems := 500
 	keys := generateRandomKeys(numItems)
-	tree := newTree(32, 1024)
+	tree := newTree(32, 8)
 	tree.Insert(keys...)
 
 	b.ResetTimer()
@@ -361,7 +360,7 @@ func BenchmarkBulkAddToExisting(b *testing.B) {
 		keySet = append(keySet, generateRandomKeys(numItems))
 	}
 
-	tree := newTree(8, 1024)
+	tree := newTree(8, 8)
 
 	b.ResetTimer()
 
@@ -373,7 +372,7 @@ func BenchmarkBulkAddToExisting(b *testing.B) {
 func BenchmarkGet(b *testing.B) {
 	numItems := 10000
 	keys := generateRandomKeys(numItems)
-	tree := newTree(32, 1024)
+	tree := newTree(32, 8)
 	tree.Insert(keys...)
 
 	b.ResetTimer()
@@ -386,7 +385,7 @@ func BenchmarkGet(b *testing.B) {
 func BenchmarkBulkGet(b *testing.B) {
 	numItems := 1000
 	keys := generateRandomKeys(numItems)
-	tree := newTree(16, 16)
+	tree := newTree(16, 8)
 	tree.Insert(keys...)
 
 	b.ResetTimer()

--- a/btree/palm/tree_test.go
+++ b/btree/palm/tree_test.go
@@ -53,10 +53,8 @@ func checkNode(t testing.TB, n *node) bool {
 		return false
 	}
 
-	i := uint64(0)
-	for iter := n.keys.list.IterAtPosition(0); iter.Next(); {
+	for i, k := range n.keys.list {
 		nd := n.nodes.list[i]
-		k := iter.Value()
 		if !assert.NotNil(t, nd) {
 			return false
 		}
@@ -65,7 +63,6 @@ func checkNode(t testing.TB, n *node) bool {
 			t.Logf(`N: %+v %p, n.keys[i]: %+v, n.nodes[i]: %+v`, n, n, k, nd)
 			return false
 		}
-		i++
 	}
 
 	k := n.keys.last()
@@ -237,7 +234,7 @@ func TestMultipleInsertCausesSplitEvenAry(t *testing.T) {
 func TestMultipleInsertCausesSplitEvenAryRandomOrder(t *testing.T) {
 	tree := newTree(4, 4)
 	defer tree.Dispose()
-	keys := generateRandomKeys(1000)
+	keys := generateRandomKeys(10)
 
 	tree.Insert(keys...)
 	if !assert.Equal(t, keys, tree.Get(keys...)) {

--- a/btree/palm/tree_test.go
+++ b/btree/palm/tree_test.go
@@ -209,7 +209,7 @@ func TestMultipleBulkInsertEvenAry(t *testing.T) {
 func TestMultipleInsertCausesSplitEvenAryReverseOrder(t *testing.T) {
 	tree := newTree(4, 4)
 	defer tree.Dispose()
-	keys := generateKeys(1000)
+	keys := generateKeys(100)
 	reversed := reverseKeys(keys)
 
 	tree.Insert(reversed...)
@@ -222,7 +222,7 @@ func TestMultipleInsertCausesSplitEvenAryReverseOrder(t *testing.T) {
 func TestMultipleInsertCausesSplitEvenAry(t *testing.T) {
 	tree := newTree(4, 4)
 	defer tree.Dispose()
-	keys := generateKeys(1000)
+	keys := generateKeys(100)
 
 	tree.Insert(keys...)
 	if !assert.Equal(t, keys, tree.Get(keys...)) {
@@ -234,7 +234,7 @@ func TestMultipleInsertCausesSplitEvenAry(t *testing.T) {
 func TestMultipleInsertCausesSplitEvenAryRandomOrder(t *testing.T) {
 	tree := newTree(4, 4)
 	defer tree.Dispose()
-	keys := generateRandomKeys(10)
+	keys := generateRandomKeys(100)
 
 	tree.Insert(keys...)
 	if !assert.Equal(t, keys, tree.Get(keys...)) {

--- a/queue/ring.go
+++ b/queue/ring.go
@@ -49,13 +49,13 @@ type nodes []*node
 // described here: http://www.1024cores.net/home/lock-free-algorithms/queues/bounded-mpmc-queue
 // with some minor additions.
 type RingBuffer struct {
-	buffer0        [8]uint64
+	_buffer0       [8]uint64
 	queue          uint64
-	buffer1        [8]uint64
+	_buffer1       [8]uint64
 	dequeue        uint64
-	buffer2        [8]uint64
+	_buffer2       [8]uint64
 	mask, disposed uint64
-	buffer3        [8]uint64
+	_buffer3       [8]uint64
 	nodes          nodes
 }
 

--- a/slice/skip/skip.go
+++ b/slice/skip/skip.go
@@ -205,14 +205,16 @@ func (sl *SkipList) search(cmp common.Comparator, update nodes, widths widths) (
 
 	var pos uint64 = 0
 	var offset uint8
+	var alreadyChecked *node
 	n := sl.head
 	for i := uint8(0); i <= sl.level; i++ {
 		offset = sl.level - i
-		for n.forward[offset] != nil && n.forward[offset].Compare(cmp) < 0 {
+		for n.forward[offset] != nil && n.forward[offset] != alreadyChecked && n.forward[offset].Compare(cmp) < 0 {
 			pos += n.widths[offset]
 			n = n.forward[offset]
 		}
 
+		alreadyChecked = n
 		if update != nil {
 			update[offset] = n
 			widths[offset] = pos


### PR DESCRIPTION
CODE REVIEW

Was able to speed up the code by using arrays instead of skiplists.  Even with the memcopy involved, you are able to keep the array size down to the size of a cache line and keep really good locality while binary searching.  Copying few items at a time is also very fast.  Also killed the recursion on splitting which saw some performance improvement.  The important factor here is how much this sped up index updates, more than a 100% increase in performance.  Going to hit the 5 million updates a second mark I think.

Further optimizations include pre-sorting a list that needs to be inserted for initial creation, finding a lockless hashmap for the layer configuration, reducing number of allocations, etc.

Need to also add deletes.

@alexandercampbell-wf @beaulyddon-wf @tannermiller-wf @ericolson-wf @stevenosborne-wf @tylertreat @rosshendrickson-wf 