### PR TITLE
Add palm deletes

### DIFF
--- a/btree/palm/action.go
+++ b/btree/palm/action.go
@@ -108,6 +108,20 @@ func newInsertAction(keys common.Comparators) *insertAction {
 	return ia
 }
 
+type removeAction struct {
+	*insertAction
+}
+
+func (ra *removeAction) operation() operation {
+	return remove
+}
+
+func newRemoveAction(keys common.Comparators) *removeAction {
+	return &removeAction{
+		newInsertAction(keys),
+	}
+}
+
 func minUint64(choices ...uint64) uint64 {
 	min := choices[0]
 	for i := 1; i < len(choices); i++ {

--- a/btree/palm/interface.go
+++ b/btree/palm/interface.go
@@ -47,6 +47,9 @@ import "github.com/Workiva/go-datastructures/common"
 type BTree interface {
 	// Insert will insert the provided keys into the tree.
 	Insert(...common.Comparator)
+	// Delete will remove the provided keys from the tree.  If no
+	// matching key is found, this is a no-op.
+	Delete(...common.Comparator)
 	// Get will return a key matching the associated provided
 	// key if it exists.
 	Get(...common.Comparator) common.Comparators

--- a/btree/palm/node.go
+++ b/btree/palm/node.go
@@ -106,14 +106,21 @@ func (ks *keys) byPosition(i uint64) common.Comparator {
 	return ks.list[i]
 }
 
-func (ks *keys) delete(k common.Comparator) {
+func (ks *keys) delete(k common.Comparator) common.Comparator {
 	i := ks.search(k)
 	if i >= uint64(len(ks.list)) {
-		return
+		return nil
 	}
+
+	if ks.list[i].Compare(k) != 0 {
+		return nil
+	}
+	old := ks.list[i]
+
 	copy(ks.list[i:], ks.list[i+1:])
 	ks.list[len(ks.list)-1] = nil // GC
 	ks.list = ks.list[:len(ks.list)-1]
+	return old
 }
 
 func (ks *keys) search(key common.Comparator) uint64 {
@@ -131,8 +138,9 @@ func (ks *keys) insert(key common.Comparator) (common.Comparator, uint64) {
 		return nil, i
 	}
 
-	old := ks.list[i]
+	var old common.Comparator
 	if ks.list[i].Compare(key) == 0 {
+		old = ks.list[i]
 		ks.list[i] = key
 	} else {
 		ks.insertAt(i, key)

--- a/btree/palm/tree_test.go
+++ b/btree/palm/tree_test.go
@@ -116,6 +116,18 @@ func TestSimpleInsert(t *testing.T) {
 	checkTree(t, tree)
 }
 
+func TestSimpleDelete(t *testing.T) {
+	tree := newTree(8, 8)
+	defer tree.Dispose()
+	m1 := mockKey(1)
+	tree.Insert(m1)
+
+	tree.Delete(m1)
+	assert.Equal(t, uint64(0), tree.Len())
+	assert.Equal(t, common.Comparators{nil}, tree.Get(m1))
+	checkTree(t, tree)
+}
+
 func TestMultipleAdd(t *testing.T) {
 	tree := newTree(16, 16)
 	defer tree.Dispose()
@@ -130,6 +142,19 @@ func TestMultipleAdd(t *testing.T) {
 	checkTree(t, tree)
 }
 
+func TestMultipleDelete(t *testing.T) {
+	tree := newTree(16, 16)
+	defer tree.Dispose()
+	m1 := mockKey(1)
+	m2 := mockKey(10)
+	tree.Insert(m1, m2)
+
+	tree.Delete(m1, m2)
+	assert.Equal(t, uint64(0), tree.Len())
+	assert.Equal(t, common.Comparators{nil, nil}, tree.Get(m1, m2))
+	checkTree(t, tree)
+}
+
 func TestMultipleInsertCausesSplitOddAryReverseOrder(t *testing.T) {
 	tree := newTree(3, 3)
 	defer tree.Dispose()
@@ -139,6 +164,22 @@ func TestMultipleInsertCausesSplitOddAryReverseOrder(t *testing.T) {
 	tree.Insert(reversed...)
 	if !assert.Equal(t, keys, tree.Get(keys...)) {
 		tree.print(getConsoleLogger())
+	}
+	checkTree(t, tree)
+}
+
+func TestMultipleDeleteOddAryReverseOrder(t *testing.T) {
+	tree := newTree(3, 3)
+	defer tree.Dispose()
+	keys := generateKeys(100)
+	reversed := reverseKeys(keys)
+	tree.Insert(reversed...)
+	assert.Equal(t, uint64(100), tree.Len())
+
+	tree.Delete(reversed...)
+	assert.Equal(t, uint64(0), tree.Len())
+	for _, k := range reversed {
+		assert.Equal(t, common.Comparators{nil}, tree.Get(k))
 	}
 	checkTree(t, tree)
 }


### PR DESCRIPTION
CODE REVIEW

Adds deletes to the PALM tree.  In a standard B-Tree this would entail merging, but it would be really hard to do that here so we leave an empty, but reusable, leaf.  Checking neighbors for merge breaks the threadsafety of that layer, and adding it to the layer above either entails passing around a lot more data or incurring a much greater cost to check children.  There's shouldn't be too much memory hit in keeping around an empty slice.

@alexandercampbell-wf @beaulyddon-wf @tannermiller-wf @rosshendrickson-wf @ericolson-wf @tylertreat @stevenosborne-wf 