### PR TITLE
Cleaned up parallel vs serial code paths a bit.

### DIFF
--- a/btree/palm/action.go
+++ b/btree/palm/action.go
@@ -168,3 +168,13 @@ func executeInterfacesInParallel(ifs interfaces, fn func(interface{})) {
 
 	wg.Wait()
 }
+
+func executeInterfacesInSerial(ifs interfaces, fn func(interface{})) {
+	if len(ifs) == 0 {
+		return
+	}
+
+	for _, ifc := range ifs {
+		fn(ifc)
+	}
+}

--- a/btree/palm/interface.go
+++ b/btree/palm/interface.go
@@ -30,13 +30,16 @@ bulk operations.
 
 Benchmarks:
 
-BenchmarkReadAndWrites-8	    			2000	    943051 ns/op
-BenchmarkSimultaneousReadsAndWrites-8	     300	   4354136 ns/op
-BenchmarkBulkAdd-8	     					 200	   5617104 ns/op
-BenchmarkAdd-8	  						  200000	      8976 ns/op
-BenchmarkBulkAddToExisting-8	     	     100	  20682933 ns/op
+BenchmarkReadAndWrites-8	    			3000	    483140 ns/op
+BenchmarkSimultaneousReadsAndWrites-8	     300	   4418123 ns/op
+BenchmarkBulkAdd-8	     					 300	   5569750 ns/op
+BenchmarkAdd-8	  						  500000		  2478 ns/op
+BenchmarkBulkAddToExisting-8	     		 100	  20552674 ns/op
 BenchmarkGet-8	 						 2000000	       629 ns/op
-BenchmarkBulkGet-8	    					5000	    217915 ns/op
+BenchmarkBulkGet-8	    					5000	    223249 ns/op
+BenchmarkDelete-8	  					  500000	      2421 ns/op
+BenchmarkBulkDelete-8	     				 500	   2790461 ns/op
+
 
 */
 package palm

--- a/btree/palm/tree_test.go
+++ b/btree/palm/tree_test.go
@@ -434,10 +434,9 @@ func BenchmarkBulkAdd(b *testing.B) {
 }
 
 func BenchmarkAdd(b *testing.B) {
-	numItems := 500
+	numItems := b.N
 	keys := generateRandomKeys(numItems)
-	tree := newTree(32, 8)
-	tree.Insert(keys...)
+	tree := newTree(8, 8) // writes will be amortized over node splits
 
 	b.ResetTimer()
 


### PR DESCRIPTION
CODE REVIEW

Modified the code a bit to reflect two possible codepaths, serial and parallel.  Serial is going to be faster for small mutations and is what should be taken for small updates.  We use a constant number compared to the number of keys mutated to determine the correct codepath to take.  We can be smarter about this in the future.  Modified the add benchmark a bit and include the amortized cost of node splits.  Fast path insert is down to ~2400ns with the amortized splits included.  I still think we can do better though.

@alexandercampbell-wf @beaulyddon-wf @tannermiller-wf @rosshendrickson-wf @ericolson-wf @stevenosborne-wf @tylertreat 