### PR TITLE
Fixed an issue in the check for interval deletion.

### DIFF
--- a/augmentedtree/atree.go
+++ b/augmentedtree/atree.go
@@ -306,7 +306,7 @@ func insertInterval(dimension uint64, interval Interval, index, count int64) int
 		return 1
 	}
 
-	if index <= low && count*-1 >= high-low {
+	if index <= low && count*-1 >= high-index {
 		return -1
 	}
 

--- a/augmentedtree/atree_test.go
+++ b/augmentedtree/atree_test.go
@@ -771,3 +771,14 @@ func TestInsertDuplicateIntervalChildren(t *testing.T) {
 	result := tree.Query(constructSingleDimensionInterval(0, 10, 0))
 	assert.Contains(t, result, iv1)
 }
+
+func TestDeleteAtDimensionalSinglePositionReference(t *testing.T) {
+	tree := newTree(2)
+	iv := constructMultiDimensionInterval(
+		0, &dimension{low: 0, high: 1}, &dimension{low: 4, high: 5},
+	)
+	tree.Add(iv)
+	modified, deleted := tree.Insert(2, 1, -1)
+	assert.Equal(t, Intervals{iv}, modified)
+	assert.Len(t, deleted, 0)
+}


### PR DESCRIPTION
CODE REVIEW

Fixes an issue where an interval was getting incorrectly deleted.  We shouldn't be checking for the size of the interval but if the enough areas were deleted that the interval was consumed in the deletion.  

@tannermiller-wf @alexandercampbell-wf @beaulyddon-wf @ericolson-wf @rosshendrickson-wf @tylertreat @stevenosborne-wf 

FYI: @bryonmarks-wf 