### PR TITLE
Hilbert duplicates

### DIFF
--- a/rtree/hilbert/action.go
+++ b/rtree/hilbert/action.go
@@ -62,7 +62,7 @@ func (ga *getAction) nodes() []*node {
 }
 
 func (ga *getAction) rects() []*hilbertBundle {
-	return nil
+	return []*hilbertBundle{&hilbertBundle{}}
 }
 
 func newGetAction(rect rtree.Rectangle) *getAction {

--- a/rtree/hilbert/node.go
+++ b/rtree/hilbert/node.go
@@ -17,15 +17,10 @@ limitations under the License.
 package hilbert
 
 import (
-	"log"
 	"sort"
 
 	"github.com/Workiva/go-datastructures/rtree"
 )
-
-func init() {
-	log.Printf(`I HATE THIS.`)
-}
 
 type hilbert int64
 

--- a/rtree/hilbert/node.go
+++ b/rtree/hilbert/node.go
@@ -17,20 +17,49 @@ limitations under the License.
 package hilbert
 
 import (
+	"log"
 	"sort"
 
 	"github.com/Workiva/go-datastructures/rtree"
 )
 
+func init() {
+	log.Printf(`I HATE THIS.`)
+}
+
 type hilbert int64
 
 type hilberts []hilbert
 
-func getParent(parent *node, key hilbert) *node {
+func getParent(parent *node, key hilbert, r1 rtree.Rectangle) *node {
 	var n *node
 	for parent != nil && !parent.isLeaf {
 		n = parent.searchNode(key)
 		parent = n
+	}
+
+	if parent != nil && r1 != nil { // must be leaf and we need exact match
+		// we are safe to travel to the right
+		i := parent.search(key)
+		for parent.keys.byPosition(i) == key {
+			if equal(parent.nodes.list[i], r1) {
+				break
+			}
+
+			i++
+			if i == parent.keys.len() {
+				if parent.right == nil { // we are far to the right
+					break
+				}
+
+				if parent.right.keys.byPosition(0) != key {
+					break
+				}
+
+				parent = parent.right
+				i = 0
+			}
+		}
 	}
 
 	return parent
@@ -195,8 +224,8 @@ type node struct {
 
 func (n *node) insert(kb *keyBundle) rtree.Rectangle {
 	i := n.keys.search(kb.key)
-	if n.isLeaf && i != n.keys.len() { // we can have multiple keys with the same hilbert number
-		for n.keys.list[i] == kb.key {
+	if n.isLeaf { // we can have multiple keys with the same hilbert number
+		for i < n.keys.len() && n.keys.list[i] == kb.key {
 			if equal(n.nodes.list[i], kb.left) {
 				old := n.nodes.list[i]
 				n.nodes.list[i] = kb.left

--- a/rtree/hilbert/tree.go
+++ b/rtree/hilbert/tree.go
@@ -424,3 +424,8 @@ func newTree(bufferSize, ary uint64) *tree {
 	tree.init(bufferSize, ary)
 	return tree
 }
+
+// New will construct a new Hilbert R-Tree and return it.
+func New(bufferSize, ary uint64) rtree.RTree {
+	return newTree(bufferSize, ary)
+}

--- a/rtree/hilbert/tree_test.go
+++ b/rtree/hilbert/tree_test.go
@@ -121,7 +121,7 @@ func TestDeleteIdenticalHilbergNumber(t *testing.T) {
 }
 
 func TestDeleteAll(t *testing.T) {
-	points := constructRandomMockPoints(5)
+	points := constructRandomMockPoints(3)
 	tree := newTree(3, 3)
 	tree.Insert(points...)
 	assert.Equal(t, uint64(len(points)), tree.Len())
@@ -346,6 +346,56 @@ func TestMultipleInsertsCauseInternalSplitEvenAryRandomOrder(t *testing.T) {
 	}
 }
 
+func TestInsertDuplicateHilbert(t *testing.T) {
+	r1 := newMockRectangle(0, 0, 20, 20)
+	r2 := newMockRectangle(1, 1, 19, 19)
+	r3 := newMockRectangle(2, 2, 18, 18)
+	r4 := newMockRectangle(3, 3, 17, 17)
+	tree := newTree(3, 3)
+	tree.Insert(r1)
+	tree.Insert(r2)
+	tree.Insert(r3)
+	tree.Insert(r4)
+
+	assert.Equal(t, uint64(4), tree.Len())
+	q := newMockRectangle(0, 0, 30, 30)
+	result := tree.Search(q)
+	assert.Len(t, result, 4)
+	assert.Contains(t, result, r1)
+	assert.Contains(t, result, r2)
+	assert.Contains(t, result, r3)
+	assert.Contains(t, result, r4)
+}
+
+func TestDeleteAllDuplicateHilbert(t *testing.T) {
+	r1 := newMockRectangle(0, 0, 20, 20)
+	r2 := newMockRectangle(1, 1, 19, 19)
+	r3 := newMockRectangle(2, 2, 18, 18)
+	r4 := newMockRectangle(3, 3, 17, 17)
+	tree := newTree(3, 3)
+	tree.Insert(r1)
+	tree.Insert(r2)
+	tree.Insert(r3)
+	tree.Insert(r4)
+
+	tree.Delete(r1, r2, r3, r4)
+	assert.Equal(t, uint64(0), tree.Len())
+	result := tree.Search(constructInfiniteRect())
+	assert.Len(t, result, 0)
+}
+
+func TestInsertDuplicateRect(t *testing.T) {
+	r1 := newMockRectangle(0, 0, 20, 20)
+	r2 := newMockRectangle(0, 0, 20, 20)
+	tree := newTree(3, 3)
+	tree.Insert(r1)
+	tree.Insert(r2)
+
+	assert.Equal(t, uint64(1), tree.Len())
+	result := tree.Search(constructInfiniteRect())
+	assert.Equal(t, rtree.Rectangles{r2}, result)
+}
+
 func BenchmarkBulkAddPoints(b *testing.B) {
 	numItems := 1000
 	points := constructMockPoints(numItems)
@@ -406,5 +456,18 @@ func BenchmarkQueryBulkPoints(b *testing.B) {
 
 	for i := int32(0); i < int32(b.N); i++ {
 		tree.Search(newMockRectangle(i, i, int32(numItems), int32(numItems)))
+	}
+}
+
+func BenchmarkDelete(b *testing.B) {
+	numItems := b.N
+	points := constructMockPoints(numItems)
+	tree := newTree(8, 8)
+	tree.Insert(points...)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		tree.Delete(points[i%numItems])
 	}
 }

--- a/rtree/interface.go
+++ b/rtree/interface.go
@@ -26,3 +26,19 @@ type Rectangle interface {
 	// UpperRight describes the upper right coordinate of this rectangle.
 	UpperRight() (int32, int32)
 }
+
+// RTree defines an object that can be returned from any subpackage
+// of this package.
+type RTree interface {
+	// Search will perform an intersection search of the given
+	// rectangle and return any rectangles that intersect.
+	Search(Rectangle) Rectangles
+	// Len returns in the number of items in the RTree.
+	Len() uint64
+	// Dispose will clean up any objects used by the RTree.
+	Dispose()
+	// Delete will remove the provided rectangles from the RTree.
+	Delete(...Rectangle)
+	// Insert will add the provided rectangles to the RTree.
+	Insert(...Rectangle)
+}


### PR DESCRIPTION
Now handle duplicates (both Rects and Hilbert numbers) properly.  Added a public constructor and a common RTree interface for the rtree package (Hilbert is currently the only subpackage, but may add R* or R+ later).  Only thing left is more extensive testing and performance optimization.  Initial numbers look pretty promising compared to interval tree, especially when it comes time to create the index from scratch with a ton of data.

@alexandercampbell-wf @beaulyddon-wf @tannermiller-wf @rosshendrickson-wf @ericolson-wf @stevenosborne-wf @tylertreat 