### PR TITLE
Ctrie

### DIFF
--- a/list/persistent.go
+++ b/list/persistent.go
@@ -1,0 +1,150 @@
+package list
+
+import "errors"
+
+var (
+	// Empty is an empty PersistentList.
+	Empty = &emptyList{}
+
+	// ErrEmptyList is returned when an invalid operation is performed on an
+	// empty list.
+	ErrEmptyList = errors.New("Empty list")
+)
+
+// PersistentList is an immutable, persistent linked list.
+type PersistentList interface {
+	// Head returns the head of the list. The bool will be false if the list is
+	// empty.
+	Head() (interface{}, bool)
+
+	// Tail returns the tail of the list. The bool will be false if the list is
+	// empty.
+	Tail() (PersistentList, bool)
+
+	// IsEmpty indicates if the list is empty.
+	IsEmpty() bool
+
+	// Add will add the item to the list, returning the new list.
+	Add(head interface{}) PersistentList
+
+	// Insert will insert the item at the given position, returning the new
+	// list or an error if the position is invalid.
+	Insert(val interface{}, pos uint) (PersistentList, error)
+
+	// Get returns the item at the given position or an error if the position
+	// is invalid.
+	Get(pos uint) (interface{}, bool)
+
+	// Remove will remove the item at the given position, returning the new
+	// list or an error if the position is invalid.
+	Remove(pos uint) (PersistentList, error)
+}
+
+type emptyList struct{}
+
+// Head returns the head of the list. The bool will be false if the list is
+// empty.
+func (e *emptyList) Head() (interface{}, bool) {
+	return nil, false
+}
+
+// Tail returns the tail of the list. The bool will be false if the list is
+// empty.
+func (e *emptyList) Tail() (PersistentList, bool) {
+	return nil, false
+}
+
+// IsEmpty indicates if the list is empty.
+func (e *emptyList) IsEmpty() bool {
+	return true
+}
+
+// Add will add the item to the list, returning the new list.
+func (e *emptyList) Add(head interface{}) PersistentList {
+	return &list{head, e}
+}
+
+// Insert will insert the item at the given position, returning the new list or
+// an error if the position is invalid.
+func (e *emptyList) Insert(val interface{}, pos uint) (PersistentList, error) {
+	if pos == 0 {
+		return e.Add(val), nil
+	}
+	return nil, ErrEmptyList
+}
+
+// Get returns the item at the given position or an error if the position is
+// invalid.
+func (e *emptyList) Get(pos uint) (interface{}, bool) {
+	return nil, false
+}
+
+// Remove will remove the item at the given position, returning the new list or
+// an error if the position is invalid.
+func (e *emptyList) Remove(pos uint) (PersistentList, error) {
+	return nil, ErrEmptyList
+}
+
+type list struct {
+	head interface{}
+	tail PersistentList
+}
+
+// Head returns the head of the list. The bool will be false if the list is
+// empty.
+func (l *list) Head() (interface{}, bool) {
+	return l.head, true
+}
+
+// Tail returns the tail of the list. The bool will be false if the list is
+// empty.
+func (l *list) Tail() (PersistentList, bool) {
+	return l.tail, true
+}
+
+// IsEmpty indicates if the list is empty.
+func (l *list) IsEmpty() bool {
+	return false
+}
+
+// Add will add the item to the list, returning the new list.
+func (l *list) Add(head interface{}) PersistentList {
+	return &list{head, l}
+}
+
+// Insert will insert the item at the given position, returning the new list or
+// an error if the position is invalid.
+func (l *list) Insert(val interface{}, pos uint) (PersistentList, error) {
+	if pos == 0 {
+		return l.Add(val), nil
+	}
+	nl, err := l.tail.Insert(val, pos-1)
+	if err != nil {
+		return nil, err
+	}
+	return nl.Add(l.head), nil
+}
+
+// Get returns the item at the given position or an error if the position is
+// invalid.
+func (l *list) Get(pos uint) (interface{}, bool) {
+	if pos == 0 {
+		return l.head, true
+	}
+	return l.tail.Get(pos - 1)
+}
+
+// Remove will remove the item at the given position, returning the new list or
+// an error if the position is invalid.
+func (l *list) Remove(pos uint) (PersistentList, error) {
+	if pos == 0 {
+		nl, _ := l.Tail()
+		return nl, nil
+	}
+
+	nl, err := l.tail.Remove(pos - 1)
+	if err != nil {
+		return nil, err
+	}
+	return &list{l.head, nl}, nil
+}

--- a/list/persistent.go
+++ b/list/persistent.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2015 Workiva, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package list
 
 import "errors"

--- a/list/persistent.go
+++ b/list/persistent.go
@@ -14,6 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+/*
+Package list provides list implementations. Currently, this includes a
+persistent, immutable linked list.
+*/
 package list
 
 import "errors"

--- a/list/persistent_test.go
+++ b/list/persistent_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2015 Workiva, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package list
 
 import (

--- a/list/persistent_test.go
+++ b/list/persistent_test.go
@@ -1,0 +1,209 @@
+package list
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEmptyList(t *testing.T) {
+	assert := assert.New(t)
+	head, ok := Empty.Head()
+	assert.Nil(head)
+	assert.False(ok)
+
+	tail, ok := Empty.Tail()
+	assert.Nil(tail)
+	assert.False(ok)
+
+	assert.True(Empty.IsEmpty())
+}
+
+func TestAdd(t *testing.T) {
+	assert := assert.New(t)
+	l1 := Empty.Add(1)
+
+	// l1: [1]
+	assert.False(l1.IsEmpty())
+	head, ok := l1.Head()
+	assert.True(ok)
+	assert.Equal(1, head)
+	tail, ok := l1.Tail()
+	assert.True(ok)
+	assert.Equal(Empty, tail)
+
+	l1 = l1.Add(2)
+
+	// l1: [2, 1]
+	head, ok = l1.Head()
+	assert.True(ok)
+	assert.Equal(2, head)
+	tail, ok = l1.Tail()
+	assert.True(ok)
+	head, ok = tail.Head()
+	assert.True(ok)
+	assert.Equal(1, head)
+
+	l2, err := l1.Insert("a", 1)
+	assert.Nil(err)
+
+	// l1: [2, 1]
+	// l2: [2, "a", 1]
+	head, ok = l1.Head()
+	assert.True(ok)
+	assert.Equal(2, head)
+	tail, ok = l1.Tail()
+	assert.True(ok)
+	head, ok = tail.Head()
+	assert.True(ok)
+	assert.Equal(1, head)
+
+	head, ok = l2.Head()
+	assert.True(ok)
+	assert.Equal(2, head)
+	tail, ok = l2.Tail()
+	assert.True(ok)
+	head, ok = tail.Head()
+	assert.True(ok)
+	assert.Equal("a", head)
+	tail, ok = tail.Tail()
+	assert.True(ok)
+	head, ok = tail.Head()
+	assert.True(ok)
+	assert.Equal(1, head)
+}
+
+func TestInsertAndGet(t *testing.T) {
+	assert := assert.New(t)
+	_, err := Empty.Insert(1, 5)
+	assert.Error(err)
+
+	l, err := Empty.Insert(1, 0)
+	assert.Nil(err)
+
+	// [1]
+	item, ok := l.Get(0)
+	assert.True(ok)
+	assert.Equal(1, item)
+
+	l, err = l.Insert(2, 0)
+	assert.Nil(err)
+
+	// [2, 1]
+	item, ok = l.Get(0)
+	assert.True(ok)
+	assert.Equal(2, item)
+	item, ok = l.Get(1)
+	assert.True(ok)
+	assert.Equal(1, item)
+
+	_, ok = l.Get(2)
+	assert.False(ok)
+
+	l, err = l.Insert("a", 3)
+	assert.Nil(l)
+	assert.Error(err)
+}
+
+func TestRemove(t *testing.T) {
+	assert := assert.New(t)
+	l, err := Empty.Remove(0)
+	assert.Nil(l)
+	assert.Error(err)
+
+	l = Empty.Add(1)
+	l = l.Add(2)
+	l = l.Add(3)
+
+	// [3, 2, 1]
+	l1, err := l.Remove(3)
+	assert.Nil(l1)
+	assert.Error(err)
+
+	l2, err := l.Remove(0)
+
+	// l: [3, 2, 1]
+	// l2: [2, 1]
+	assert.Nil(err)
+	head, ok := l.Head()
+	assert.True(ok)
+	assert.Equal(3, head)
+	tail, ok := l.Tail()
+	assert.True(ok)
+	head, ok = tail.Head()
+	assert.True(ok)
+	assert.Equal(2, head)
+	tail, ok = tail.Tail()
+	assert.True(ok)
+	head, ok = tail.Head()
+	assert.True(ok)
+	assert.Equal(1, head)
+
+	assert.Nil(err)
+	head, ok = l2.Head()
+	assert.True(ok)
+	assert.Equal(2, head)
+	tail, ok = l2.Tail()
+	assert.True(ok)
+	head, ok = tail.Head()
+	assert.True(ok)
+	assert.Equal(1, head)
+
+	l2, err = l.Remove(1)
+
+	// l: [3, 2, 1]
+	// l2: [3, 1]
+	assert.Nil(err)
+	head, ok = l.Head()
+	assert.True(ok)
+	assert.Equal(3, head)
+	tail, ok = l.Tail()
+	assert.True(ok)
+	head, ok = tail.Head()
+	assert.True(ok)
+	assert.Equal(2, head)
+	tail, ok = tail.Tail()
+	assert.True(ok)
+	head, ok = tail.Head()
+	assert.True(ok)
+	assert.Equal(1, head)
+
+	assert.Nil(err)
+	head, ok = l2.Head()
+	assert.True(ok)
+	assert.Equal(3, head)
+	tail, ok = l2.Tail()
+	assert.True(ok)
+	head, ok = tail.Head()
+	assert.True(ok)
+	assert.Equal(1, head)
+
+	l2, err = l.Remove(2)
+
+	// l: [3, 2, 1]
+	// l2: [3, 2]
+	assert.Nil(err)
+	head, ok = l.Head()
+	assert.True(ok)
+	assert.Equal(3, head)
+	tail, ok = l.Tail()
+	assert.True(ok)
+	head, ok = tail.Head()
+	assert.True(ok)
+	assert.Equal(2, head)
+	tail, ok = tail.Tail()
+	assert.True(ok)
+	head, ok = tail.Head()
+	assert.True(ok)
+	assert.Equal(1, head)
+
+	assert.Nil(err)
+	head, ok = l2.Head()
+	assert.True(ok)
+	assert.Equal(3, head)
+	tail, ok = l2.Tail()
+	assert.True(ok)
+	head, ok = tail.Head()
+	assert.True(ok)
+	assert.Equal(2, head)
+}

--- a/list/persistent_test.go
+++ b/list/persistent_test.go
@@ -207,3 +207,56 @@ func TestRemove(t *testing.T) {
 	assert.True(ok)
 	assert.Equal(2, head)
 }
+
+func TestFind(t *testing.T) {
+	assert := assert.New(t)
+	pred := func(item interface{}) bool {
+		return item == 1
+	}
+
+	found, ok := Empty.Find(pred)
+	assert.Nil(found)
+	assert.False(ok)
+
+	l := Empty.Add("blah").Add("bleh")
+
+	found, ok = l.Find(pred)
+	assert.Nil(found)
+	assert.False(ok)
+
+	l = l.Add(1).Add("foo")
+
+	found, ok = l.Find(pred)
+	assert.Equal(1, found)
+	assert.True(ok)
+}
+
+func TestFindIndex(t *testing.T) {
+	assert := assert.New(t)
+	pred := func(item interface{}) bool {
+		return item == 1
+	}
+
+	idx := Empty.FindIndex(pred)
+	assert.Equal(-1, idx)
+
+	l := Empty.Add("blah").Add("bleh")
+
+	idx = l.FindIndex(pred)
+	assert.Equal(-1, idx)
+
+	l = l.Add(1).Add("foo")
+
+	idx = l.FindIndex(pred)
+	assert.Equal(1, idx)
+}
+
+func TestLength(t *testing.T) {
+	assert := assert.New(t)
+	assert.Equal(uint(0), Empty.Length())
+
+	l := Empty.Add("foo")
+	assert.Equal(uint(1), l.Length())
+	l = l.Add("bar").Add("baz")
+	assert.Equal(uint(3), l.Length())
+}

--- a/trie/ctrie/ctrie.go
+++ b/trie/ctrie/ctrie.go
@@ -9,7 +9,10 @@ import (
 	"unsafe"
 )
 
-const w = 5
+const (
+	w    = 5
+	exp2 = 32
+)
 
 type Ctrie struct {
 	root *iNode
@@ -33,12 +36,18 @@ type cNode struct {
 	array []branch
 }
 
+// newMainNode is a recursive constructor which creates a new mainNode. This
+// mainNode will consist of cNodes as long as the hashcode chunks of the two
+// keys are equal at the given level. If the level exceeds 2^w, an lNode is
+// created.
 func newMainNode(x *sNode, xhc uint32, y *sNode, yhc uint32, lev uint) *mainNode {
-	if lev < 35 {
+	if lev < exp2 {
 		xidx := (xhc >> lev) & 0x1f
 		yidx := (yhc >> lev) & 0x1f
 		bmp := uint32((1 << xidx) | (1 << yidx))
+
 		if xidx == yidx {
+			// Recurse when indexes are equal.
 			main := newMainNode(x, xhc, y, yhc, lev+w)
 			iNode := &iNode{main}
 			return &mainNode{cNode: &cNode{bmp, []branch{iNode}}}

--- a/trie/ctrie/ctrie.go
+++ b/trie/ctrie/ctrie.go
@@ -105,9 +105,7 @@ func (c *cNode) inserted(pos, flag uint32, br branch) *cNode {
 	length := uint32(len(c.array))
 	bmp := c.bmp
 	array := make([]branch, length+1)
-	for i := uint32(0); i < pos; i++ {
-		array[i] = c.array[i]
-	}
+	copy(array, c.array)
 	array[pos] = br
 	for i, x := pos, uint32(0); x < length-pos; i++ {
 		array[i+1] = c.array[i]
@@ -121,9 +119,7 @@ func (c *cNode) inserted(pos, flag uint32, br branch) *cNode {
 // updated.
 func (c *cNode) updated(pos uint32, br branch) *cNode {
 	array := make([]branch, len(c.array))
-	for i, branch := range c.array {
-		array[i] = branch
-	}
+	copy(array, c.array)
 	array[pos] = br
 	ncn := &cNode{bmp: c.bmp, array: array}
 	return ncn

--- a/trie/ctrie/ctrie.go
+++ b/trie/ctrie/ctrie.go
@@ -9,10 +9,7 @@ import (
 	"unsafe"
 )
 
-const (
-	w    = 5
-	exp2 = 32
-)
+const w = 5
 
 type Ctrie struct {
 	root *iNode

--- a/trie/ctrie/ctrie.go
+++ b/trie/ctrie/ctrie.go
@@ -493,10 +493,8 @@ func toContracted(cn *cNode, lev uint) *mainNode {
 
 // toCompressed compacts the C-node as a performance optimization.
 func toCompressed(cn *cNode, lev uint) *mainNode {
-	bmp := cn.bmp
-	arr := cn.array
-	tmpArray := make([]branch, len(arr))
-	for i, sub := range arr {
+	tmpArray := make([]branch, len(cn.array))
+	for i, sub := range cn.array {
 		switch sub.(type) {
 		case *iNode:
 			inode := sub.(*iNode)
@@ -510,7 +508,7 @@ func toCompressed(cn *cNode, lev uint) *mainNode {
 		}
 	}
 
-	return toContracted(&cNode{bmp: bmp, array: tmpArray}, lev)
+	return toContracted(&cNode{bmp: cn.bmp, array: tmpArray}, lev)
 }
 
 func entomb(m *sNode) *mainNode {

--- a/trie/ctrie/ctrie.go
+++ b/trie/ctrie/ctrie.go
@@ -14,6 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+/*
+Package ctrie provides an implementation of the Ctrie data structure, which is
+a concurrent, lock-free hash trie. This data structure was originally presented
+in the paper Concurrent Tries with Efficient Non-Blocking Snapshots:
+
+https://axel22.github.io/resources/docs/ctries-snapshot.pdf
+
+TODO: Add snapshot support.
+*/
 package ctrie
 
 import (

--- a/trie/ctrie/ctrie.go
+++ b/trie/ctrie/ctrie.go
@@ -1,0 +1,263 @@
+package ctrie
+
+import (
+	"bytes"
+	"hash"
+	"hash/fnv"
+	"sync/atomic"
+	"unsafe"
+)
+
+const (
+	w    = 5
+	exp2 = 32
+)
+
+type Ctrie struct {
+	root *iNode
+	h    hash.Hash64
+}
+
+type iNode struct {
+	main *mainNode
+}
+
+// mainNode is either a cNode, tNode, or lNode.
+type mainNode struct {
+	cNode *cNode
+	tNode *tNode
+	lNode *lNode
+}
+
+type cNode struct {
+	bmp   uint32
+	array []branch
+}
+
+func newMainNode(x *sNode, xhc uint64, y *sNode, yhc uint64, lev uint) *mainNode {
+	if lev < 35 {
+		xidx := (xhc >> lev) & 0x1f
+		yidx := (yhc >> lev) & 0x1f
+		bmp := uint32((1 << xidx) | (1 << yidx))
+		if xidx == yidx {
+			main := newMainNode(x, xhc, y, yhc, lev+w)
+			iNode := &iNode{main}
+			return &mainNode{cNode: &cNode{bmp, []branch{iNode}}}
+		}
+		if xidx < yidx {
+			return &mainNode{cNode: &cNode{bmp, []branch{x, y}}}
+		}
+		return &mainNode{cNode: &cNode{bmp, []branch{y, x}}}
+	}
+	return &mainNode{lNode: &lNode{sn: x, next: &lNode{sn: y}}}
+}
+
+// inserted returns a copy of this cNode with the new entry at the given
+// position.
+func (c *cNode) inserted(pos, flag uint32, br branch) *cNode {
+	length := uint32(len(c.array))
+	bmp := c.bmp
+	array := make([]branch, length+1)
+	for i := uint32(0); i < pos; i++ {
+		array[i] = c.array[i]
+	}
+	array[pos] = br
+	for i, x := pos, uint32(0); x < length-pos; i++ {
+		array[i+1] = c.array[i]
+		x++
+	}
+	ncn := &cNode{bmp: bmp | flag, array: array}
+	return ncn
+}
+
+// updated returns a copy of this cNode with the entry at the given index
+// updated.
+func (c *cNode) updated(pos uint32, br branch) *cNode {
+	array := make([]branch, len(c.array))
+	for i, branch := range c.array {
+		array[i] = branch
+	}
+	array[pos] = br
+	ncn := &cNode{bmp: c.bmp, array: array}
+	return ncn
+}
+
+type tNode struct {
+	sn *sNode
+}
+
+type lNode struct {
+	sn   *sNode
+	next *lNode
+}
+
+// branch is either an iNode or sNode.
+type branch interface{}
+
+type entry struct {
+	key   []byte
+	hash  uint64
+	value interface{}
+}
+
+type sNode struct {
+	*entry
+}
+
+func New() *Ctrie {
+	root := &iNode{main: &mainNode{cNode: &cNode{}}}
+	return &Ctrie{root: root, h: fnv.New64a()}
+}
+
+func (c *Ctrie) Insert(key []byte, value interface{}) {
+	c.insert(&entry{
+		key:   key,
+		hash:  c.hash(key),
+		value: value,
+	})
+}
+
+func (c *Ctrie) Lookup(key []byte) (interface{}, bool) {
+	return c.lookup(&entry{key: key, hash: c.hash(key)})
+}
+
+func (c *Ctrie) insert(entry *entry) {
+	rootPtr := (*unsafe.Pointer)(unsafe.Pointer(&c.root))
+	root := (*iNode)(atomic.LoadPointer(rootPtr))
+	if !iinsert(root, entry, 0, nil) {
+		c.insert(entry)
+	}
+}
+
+func (c *Ctrie) lookup(entry *entry) (interface{}, bool) {
+	rootPtr := (*unsafe.Pointer)(unsafe.Pointer(&c.root))
+	root := (*iNode)(atomic.LoadPointer(rootPtr))
+	result, exists, ok := ilookup(root, entry, 0, nil)
+	for !ok {
+		return c.lookup(entry)
+	}
+	return result, exists
+}
+
+func (c *Ctrie) hash(k []byte) uint64 {
+	c.h.Write(k)
+	hash := c.h.Sum64()
+	c.h.Reset()
+	return hash
+}
+
+func iinsert(i *iNode, entry *entry, lev uint, parent *iNode) bool {
+	mainPtr := (*unsafe.Pointer)(unsafe.Pointer(&i.main))
+	main := (*mainNode)(atomic.LoadPointer(mainPtr))
+	switch {
+	case main.cNode != nil:
+		cn := main.cNode
+		flag, pos := flagPos(entry.hash, lev, cn.bmp)
+		if cn.bmp&flag == 0 {
+			// If the relevant bit is not in the bitmap, then a copy of the
+			// cNode with the new entry is created. The linearization point is
+			// a successful CAS.
+			ncn := &mainNode{cNode: cn.inserted(pos, flag, &sNode{entry})}
+			return atomic.CompareAndSwapPointer(mainPtr, unsafe.Pointer(main), unsafe.Pointer(ncn))
+		}
+		// If the relevant bit is present in the bitmap, then its corresponding
+		// branch is read from the array.
+		branch := cn.array[pos]
+		switch branch.(type) {
+		case *iNode:
+			// If the branch is an I-node, then iinsert is called recursively.
+			return iinsert(branch.(*iNode), entry, lev+w, i)
+		case *sNode:
+			sn := branch.(*sNode)
+			if !bytes.Equal(sn.key, entry.key) {
+				// If the branch is an S-node and its key is not equal to the
+				// key being inserted, then the Ctrie has to be extended with
+				// an additional level. The C-node is replaced with its updated
+				// version, created using the updated function that adds a new
+				// I-node at the respective position. The new Inode has its
+				// main node pointing to a C-node with both keys. The
+				// linearization point is a successful CAS.
+				nsn := &sNode{entry}
+				nin := &iNode{newMainNode(sn, sn.hash, nsn, nsn.hash, lev+w)}
+				ncn := &mainNode{cNode: cn.updated(pos, nin)}
+				return atomic.CompareAndSwapPointer(mainPtr, unsafe.Pointer(main), unsafe.Pointer(ncn))
+			}
+			// If the key in the S-node is equal to the key being inserted,
+			// then the C-node is replaced with its updated version with a new
+			// S-node. The linearization point is a successful CAS.
+			ncn := &mainNode{cNode: cn.updated(pos, &sNode{entry})}
+			return atomic.CompareAndSwapPointer(mainPtr, unsafe.Pointer(main), unsafe.Pointer(ncn))
+		default:
+			panic("Ctrie is in an invalid state")
+		}
+	case main.tNode != nil:
+		// TODO
+		return true
+	case main.lNode != nil:
+		// TODO
+		return true
+	default:
+		panic("Ctrie is in an invalid state")
+	}
+}
+
+func ilookup(i *iNode, entry *entry, lev uint, parent *iNode) (interface{}, bool, bool) {
+	mainPtr := (*unsafe.Pointer)(unsafe.Pointer(&i.main))
+	// Linearization point.
+	main := (*mainNode)(atomic.LoadPointer(mainPtr))
+	switch {
+	case main.cNode != nil:
+		cn := main.cNode
+		flag, pos := flagPos(entry.hash, lev, cn.bmp)
+		if cn.bmp&flag == 0 {
+			// If the bitmap does not contain the relevant bit, a key with the
+			// required hashcode prefix is not present in the trie.
+			return nil, false, true
+		}
+		// Otherwise, the relevant branch at index pos is read from the array.
+		branch := cn.array[pos]
+		switch branch.(type) {
+		case *iNode:
+			// If the branch is an I-node, the ilookup procedure is called
+			// recursively at the next level.
+			return ilookup(branch.(*iNode), entry, lev+w, i)
+		case *sNode:
+			// If the branch is an S-node, then the key within the S-node is
+			// compared with the key being searched – these two keys have the
+			// same hashcode prefixes, but they need not be equal. If they are
+			// equal, the corresponding value from the S-node is
+			// returned and a NOTFOUND value otherwise.
+			sn := branch.(*sNode)
+			if bytes.Equal(sn.key, entry.key) {
+				return sn.value, true, true
+			}
+			return nil, false, true
+		default:
+			panic("Ctrie is in an invalid state")
+		}
+	case main.tNode != nil:
+		// TODO
+		return nil, false, true
+	case main.lNode != nil:
+		// TODO
+		return nil, false, true
+	default:
+		panic("Ctrie is in an invalid state")
+	}
+}
+
+func flagPos(hashcode uint64, lev uint, bmp uint32) (uint32, uint32) {
+	idx := (hashcode >> lev) & 0x1f
+	flag := uint32(1) << uint32(idx)
+	mask := uint32(flag - 1)
+	pos := bitCount(bmp & mask)
+	return flag, pos
+}
+
+func bitCount(x uint32) uint32 {
+	x = ((x >> 1) & 0x55555555) + (x & 0x55555555)
+	x = ((x >> 2) & 0x33333333) + (x & 0x33333333)
+	x = ((x >> 4) & 0x0f0f0f0f) + (x & 0x0f0f0f0f)
+	x = ((x >> 8) & 0x00ff00ff) + (x & 0x00ff00ff)
+	return ((x >> 16) & 0x0000ffff) + (x & 0x0000ffff)
+}

--- a/trie/ctrie/ctrie.go
+++ b/trie/ctrie/ctrie.go
@@ -16,7 +16,7 @@ const (
 
 type Ctrie struct {
 	root *iNode
-	h    hash.Hash64
+	h    hash.Hash32
 	hMu  sync.Mutex
 }
 
@@ -36,7 +36,7 @@ type cNode struct {
 	array []branch
 }
 
-func newMainNode(x *sNode, xhc uint64, y *sNode, yhc uint64, lev uint) *mainNode {
+func newMainNode(x *sNode, xhc uint32, y *sNode, yhc uint32, lev uint) *mainNode {
 	if lev < 35 {
 		xidx := (xhc >> lev) & 0x1f
 		yidx := (yhc >> lev) & 0x1f
@@ -142,7 +142,7 @@ type branch interface{}
 
 type entry struct {
 	key   []byte
-	hash  uint64
+	hash  uint32
 	value interface{}
 }
 
@@ -152,10 +152,10 @@ type sNode struct {
 
 func New() *Ctrie {
 	root := &iNode{main: &mainNode{cNode: &cNode{}}}
-	return &Ctrie{root: root, h: fnv.New64a()}
+	return &Ctrie{root: root, h: fnv.New32a()}
 }
 
-func (c *Ctrie) SetHash(hash hash.Hash64) {
+func (c *Ctrie) SetHash(hash hash.Hash32) {
 	c.hMu.Lock()
 	c.h = hash
 	c.hMu.Unlock()
@@ -205,10 +205,10 @@ func (c *Ctrie) remove(entry *entry) (interface{}, bool) {
 	return result, exists
 }
 
-func (c *Ctrie) hash(k []byte) uint64 {
+func (c *Ctrie) hash(k []byte) uint32 {
 	c.hMu.Lock()
 	c.h.Write(k)
-	hash := c.h.Sum64()
+	hash := c.h.Sum32()
 	c.h.Reset()
 	c.hMu.Unlock()
 	return hash
@@ -436,7 +436,7 @@ func clean(i *iNode, lev uint) bool {
 	return true
 }
 
-func cleanParent(p, i *iNode, hc uint64, lev uint) {
+func cleanParent(p, i *iNode, hc uint32, lev uint) {
 	var (
 		mainPtr  = (*unsafe.Pointer)(unsafe.Pointer(&i.main))
 		main     = (*mainNode)(atomic.LoadPointer(mainPtr))
@@ -458,7 +458,7 @@ func cleanParent(p, i *iNode, hc uint64, lev uint) {
 	}
 }
 
-func flagPos(hashcode uint64, lev uint, bmp uint32) (uint32, uint32) {
+func flagPos(hashcode uint32, lev uint, bmp uint32) (uint32, uint32) {
 	idx := (hashcode >> lev) & 0x1f
 	flag := uint32(1) << uint32(idx)
 	mask := uint32(flag - 1)

--- a/trie/ctrie/ctrie.go
+++ b/trie/ctrie/ctrie.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2015 Workiva, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package ctrie
 
 import (

--- a/trie/ctrie/ctrie.go
+++ b/trie/ctrie/ctrie.go
@@ -494,11 +494,9 @@ func toContracted(cn *cNode, lev uint) *mainNode {
 // toCompressed compacts the C-node as a performance optimization.
 func toCompressed(cn *cNode, lev uint) *mainNode {
 	bmp := cn.bmp
-	i := 0
 	arr := cn.array
 	tmpArray := make([]branch, len(arr))
-	for i < len(arr) {
-		sub := arr[i]
+	for i, sub := range arr {
 		switch sub.(type) {
 		case *iNode:
 			inode := sub.(*iNode)
@@ -510,7 +508,6 @@ func toCompressed(cn *cNode, lev uint) *mainNode {
 		default:
 			panic("Ctrie is in an invalid state")
 		}
-		i++
 	}
 
 	return toContracted(&cNode{bmp: bmp, array: tmpArray}, lev)

--- a/trie/ctrie/ctrie_test.go
+++ b/trie/ctrie/ctrie_test.go
@@ -1,0 +1,46 @@
+package ctrie
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInsertAndLookup(t *testing.T) {
+	assert := assert.New(t)
+	ctrie := New()
+
+	_, ok := ctrie.Lookup([]byte("foo"))
+	assert.False(ok)
+
+	ctrie.Insert([]byte("foo"), "bar")
+	val, ok := ctrie.Lookup([]byte("foo"))
+	assert.True(ok)
+	assert.Equal("bar", val)
+
+	ctrie.Insert([]byte("fooooo"), "baz")
+	val, ok = ctrie.Lookup([]byte("foo"))
+	assert.True(ok)
+	assert.Equal("bar", val)
+	val, ok = ctrie.Lookup([]byte("fooooo"))
+	assert.True(ok)
+	assert.Equal("baz", val)
+
+	for i := 0; i < 100; i++ {
+		ctrie.Insert([]byte(strconv.Itoa(i)), "blah")
+	}
+	for i := 0; i < 100; i++ {
+		val, ok = ctrie.Lookup([]byte(strconv.Itoa(i)))
+		assert.True(ok)
+		assert.Equal("blah", val)
+	}
+
+	val, ok = ctrie.Lookup([]byte("foo"))
+	assert.True(ok)
+	assert.Equal("bar", val)
+	ctrie.Insert([]byte("foo"), "qux")
+	val, ok = ctrie.Lookup([]byte("foo"))
+	assert.True(ok)
+	assert.Equal("qux", val)
+}

--- a/trie/ctrie/ctrie_test.go
+++ b/trie/ctrie/ctrie_test.go
@@ -29,7 +29,7 @@ import (
 
 func TestCtrie(t *testing.T) {
 	assert := assert.New(t)
-	ctrie := New()
+	ctrie := New(nil)
 
 	_, ok := ctrie.Lookup([]byte("foo"))
 	assert.False(ok)
@@ -88,10 +88,13 @@ func (m *mockHash32) Sum32() uint32 {
 	return 0
 }
 
+func mockHashFactory() hash.Hash32 {
+	return &mockHash32{fnv.New32a()}
+}
+
 func TestInsertLNode(t *testing.T) {
 	assert := assert.New(t)
-	ctrie := New()
-	ctrie.SetHash(&mockHash32{fnv.New32a()})
+	ctrie := New(mockHashFactory)
 
 	for i := 0; i < 10; i++ {
 		ctrie.Insert([]byte(strconv.Itoa(i)), i)
@@ -114,7 +117,7 @@ func TestInsertLNode(t *testing.T) {
 
 func TestInsertTNode(t *testing.T) {
 	assert := assert.New(t)
-	ctrie := New()
+	ctrie := New(nil)
 
 	for i := 0; i < 100000; i++ {
 		ctrie.Insert([]byte(strconv.Itoa(i)), i)
@@ -137,7 +140,7 @@ func TestInsertTNode(t *testing.T) {
 
 func TestConcurrency(t *testing.T) {
 	assert := assert.New(t)
-	ctrie := New()
+	ctrie := New(nil)
 	var wg sync.WaitGroup
 	wg.Add(2)
 
@@ -167,7 +170,7 @@ func TestConcurrency(t *testing.T) {
 }
 
 func BenchmarkInsert(b *testing.B) {
-	ctrie := New()
+	ctrie := New(nil)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		ctrie.Insert([]byte("foo"), 0)
@@ -176,7 +179,7 @@ func BenchmarkInsert(b *testing.B) {
 
 func BenchmarkLookup(b *testing.B) {
 	numItems := 1000
-	ctrie := New()
+	ctrie := New(nil)
 	for i := 0; i < numItems; i++ {
 		ctrie.Insert([]byte(strconv.Itoa(i)), i)
 	}
@@ -190,7 +193,7 @@ func BenchmarkLookup(b *testing.B) {
 
 func BenchmarkRemove(b *testing.B) {
 	numItems := 1000
-	ctrie := New()
+	ctrie := New(nil)
 	for i := 0; i < numItems; i++ {
 		ctrie.Insert([]byte(strconv.Itoa(i)), i)
 	}

--- a/trie/ctrie/ctrie_test.go
+++ b/trie/ctrie/ctrie_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestInsertAndLookup(t *testing.T) {
+func TestCtrie(t *testing.T) {
 	assert := assert.New(t)
 	ctrie := New()
 
@@ -43,6 +43,21 @@ func TestInsertAndLookup(t *testing.T) {
 	val, ok = ctrie.Lookup([]byte("foo"))
 	assert.True(ok)
 	assert.Equal("qux", val)
+
+	val, ok = ctrie.Remove([]byte("foo"))
+	assert.True(ok)
+	assert.Equal("qux", val)
+
+	_, ok = ctrie.Remove([]byte("foo"))
+	assert.False(ok)
+
+	val, ok = ctrie.Remove([]byte("fooooo"))
+	assert.True(ok)
+	assert.Equal("baz", val)
+
+	for i := 0; i < 100; i++ {
+		ctrie.Remove([]byte(strconv.Itoa(i)))
+	}
 }
 
 func BenchmarkInsert(b *testing.B) {

--- a/trie/ctrie/ctrie_test.go
+++ b/trie/ctrie/ctrie_test.go
@@ -44,3 +44,25 @@ func TestInsertAndLookup(t *testing.T) {
 	assert.True(ok)
 	assert.Equal("qux", val)
 }
+
+func BenchmarkInsert(b *testing.B) {
+	ctrie := New()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ctrie.Insert([]byte("foo"), 0)
+	}
+}
+
+func BenchmarkLookup(b *testing.B) {
+	numItems := 1000
+	ctrie := New()
+	for i := 0; i < numItems; i++ {
+		ctrie.Insert([]byte(strconv.Itoa(i)), i)
+	}
+	key := []byte(strconv.Itoa(numItems / 2))
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		ctrie.Lookup(key)
+	}
+}

--- a/trie/ctrie/ctrie_test.go
+++ b/trie/ctrie/ctrie_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2015 Workiva, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package ctrie
 
 import (


### PR DESCRIPTION
This includes an implementation of a [Ctrie](https://axel22.github.io/resources/docs/ctries-snapshot.pdf), which is a concurrent, lock-free hash trie. This supports insert, remove, and lookup. Snapshot isn't supported yet, but I plan to add it later.

Benchmarks if you're curious:
BenchmarkInsert-8        3000000               449 ns/op
BenchmarkLookup-8       10000000               224 ns/op
BenchmarkRemove-8       10000000               192 ns/op

This also includes an implementation of a persistent, immutable linked list (which the Ctrie uses).

@dustinhiatt-wf @alexandercampbell-wf @beaulyddon-wf @tannermiller-wf @rosshendrickson-wf @stevenosborne-wf 