### PR TITLE
Ctrie Snapshots

### DIFF
--- a/trie/ctrie/ctrie.go
+++ b/trie/ctrie/ctrie.go
@@ -330,7 +330,7 @@ func (c *Ctrie) ReadOnlySnapshot() *Ctrie {
 		root := c.readRoot()
 		main := gcasRead(root, c)
 		if c.rdcssRoot(root, main, root.copyToGen(&generation{}, c)) {
-			return newCtrie(root.copyToGen(&generation{}, c), c.hashFactory, true)
+			return newCtrie(root, c.hashFactory, true)
 		}
 	}
 }

--- a/trie/ctrie/ctrie.go
+++ b/trie/ctrie/ctrie.go
@@ -642,7 +642,7 @@ func clean(i *iNode, lev uint, ctrie *Ctrie) bool {
 	return true
 }
 
-func cleanReadOnly(tn *tNode, lev uint, p *iNode, ctrie *Ctrie, entry *entry) (interface{}, bool, bool) {
+func cleanReadOnly(tn *tNode, lev uint, p *iNode, ctrie *Ctrie, entry *entry) (val interface{}, exists bool, ok bool) {
 	if !ctrie.readOnly {
 		clean(p, lev-5, ctrie)
 		return nil, false, false

--- a/trie/ctrie/ctrie.go
+++ b/trie/ctrie/ctrie.go
@@ -184,9 +184,9 @@ func (c *cNode) removed(pos, flag uint32, gen *generation) *cNode {
 func (c *cNode) renewed(gen *generation, ctrie *Ctrie) *cNode {
 	array := make([]branch, len(c.array))
 	for i, br := range c.array {
-		switch br.(type) {
+		switch t := br.(type) {
 		case *iNode:
-			array[i] = br.(*iNode).copyToGen(gen, ctrie)
+			array[i] = t.copyToGen(gen, ctrie)
 		default:
 			array[i] = br
 		}

--- a/trie/ctrie/ctrie.go
+++ b/trie/ctrie/ctrie.go
@@ -97,10 +97,6 @@ type mainNode struct {
 	prev *mainNode
 }
 
-type failedNode struct {
-	*mainNode
-}
-
 // cNode is an internal main node containing a bitmap and the array with
 // references to branch nodes. A branch node is either another I-node or a
 // singleton S-node.

--- a/trie/ctrie/ctrie_test.go
+++ b/trie/ctrie/ctrie_test.go
@@ -237,6 +237,20 @@ func TestSnapshot(t *testing.T) {
 		assert.NotNil(recover())
 	}()
 	snapshot.Remove([]byte("blah"))
+
+	// Ensure snapshots-of-snapshots work as expected.
+	snapshot2 := snapshot.Snapshot()
+	for i := 0; i < 100; i++ {
+		val, ok := snapshot2.Lookup([]byte(strconv.Itoa(i)))
+		assert.True(ok)
+		assert.Equal(i, val)
+	}
+	snapshot2.Remove([]byte("0"))
+	_, ok = snapshot2.Lookup([]byte("0"))
+	assert.False(ok)
+	val, ok = snapshot.Lookup([]byte("0"))
+	assert.True(ok)
+	assert.Equal(0, val)
 }
 
 func BenchmarkInsert(b *testing.B) {

--- a/trie/ctrie/ctrie_test.go
+++ b/trie/ctrie/ctrie_test.go
@@ -224,6 +224,19 @@ func TestSnapshot(t *testing.T) {
 	}
 	_, ok = ctrie.Lookup([]byte("bat"))
 	assert.False(ok)
+
+	snapshot = ctrie.ReadOnlySnapshot()
+	for i := 0; i < 100; i++ {
+		val, ok := snapshot.Lookup([]byte(strconv.Itoa(i)))
+		assert.True(ok)
+		assert.Equal(i, val)
+	}
+
+	// Ensure read-only snapshots panic on writes.
+	defer func() {
+		assert.NotNil(recover())
+	}()
+	snapshot.Remove([]byte("blah"))
 }
 
 func BenchmarkInsert(b *testing.B) {

--- a/trie/ctrie/ctrie_test.go
+++ b/trie/ctrie/ctrie_test.go
@@ -274,3 +274,29 @@ func BenchmarkRemove(b *testing.B) {
 		ctrie.Remove(key)
 	}
 }
+
+func BenchmarkSnapshot(b *testing.B) {
+	numItems := 1000
+	ctrie := New(nil)
+	for i := 0; i < numItems; i++ {
+		ctrie.Insert([]byte(strconv.Itoa(i)), i)
+	}
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		ctrie.Snapshot()
+	}
+}
+
+func BenchmarkReadOnlySnapshot(b *testing.B) {
+	numItems := 1000
+	ctrie := New(nil)
+	for i := 0; i < numItems; i++ {
+		ctrie.Insert([]byte(strconv.Itoa(i)), i)
+	}
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		ctrie.ReadOnlySnapshot()
+	}
+}


### PR DESCRIPTION
This implements snapshot support for Ctries. Snapshots pave the way for operations which require global information like stable iterators, size, clear, etc. The code gets a bit hairy, but the basic idea is this:

- Assign a generation to each node.
- To snapshot, copy the root I-node and set it to a new generation.
- When an update operation detects that the generation of the I-node it's reading is older than that of the root, it copies the I-node to the new generation and updates the parent (lazy updating).
- Perform CAS operations using a GCAS, which is effectively a [RDCSS](http://www.cl.cam.ac.uk/research/srg/netos/papers/2002-casn.pdf). What this means is in order for the CAS to succeed, the root's generation has not changed.

Because the snapshot updates occur lazily, the snapshot operation is O(1) while all other operations remain O(logn). Snapshots can be mutated, but we also provide support for read-only snapshots.

@dustinhiatt-wf @alexandercampbell-wf @beaulyddon-wf @tannermiller-wf @rosshendrickson-wf @stevenosborne-wf