### PR TITLE
Ctrie Iterator

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,28 @@ immutable version.  Unfortunately, to make the B-tree generic we require an
 interface and the most expensive operation in CPU profiling is the interface
 method which in turn calls into runtime.assertI2T.  We need generics.
 
+#### Ctrie
+
+A concurrent, lock-free hash array mapped trie with efficient non-blocking
+snapshots. For lookups, Ctries have comparable performance to concurrent skip
+lists and concurrent hashmaps. One key advantage of Ctries is they are
+dynamically allocated. Memory consumption is always proportional to the number
+of keys in the Ctrie, while hashmaps typically have to grow and shrink. Lookups,
+inserts, and removes are O(logn).
+
+One interesting advantage Ctries have over traditional concurrent data
+structures is support for lock-free, linearizable, constant-time snapshots.
+Most concurrent data structures do not support snapshots, instead opting for
+locks or requiring a quiescent state. This allows Ctries to have O(1) iterator
+creation and clear operations and O(logn) size retrieval.
+
+#### Persistent List
+
+A persistent, immutable linked list. All write operations yield a new, updated
+structure which preserve and reuse previous versions. This uses a very
+functional, cons-style of list manipulation. Insert, get, remove, and size
+operations are O(n) as you would expect.
+
 ### Installation
 
  1. Install Go 1.3 or higher.

--- a/list/persistent.go
+++ b/list/persistent.go
@@ -69,6 +69,10 @@ type PersistentList interface {
 	// FindIndex applies the predicate function to the list and returns the
 	// index of the first item which matches or -1 if there is no match.
 	FindIndex(func(interface{}) bool) int
+
+	// Map applies the function to each entry in the list and returns the
+	// resulting slice.
+	Map(func(interface{}) interface{}) []interface{}
 }
 
 type emptyList struct{}
@@ -131,6 +135,12 @@ func (e *emptyList) Find(func(interface{}) bool) (interface{}, bool) {
 // of the first item which matches or -1 if there is no match.
 func (e *emptyList) FindIndex(func(interface{}) bool) int {
 	return -1
+}
+
+// Map applies the function to each entry in the list and returns the resulting
+// slice.
+func (e *emptyList) Map(func(interface{}) interface{}) []interface{} {
+	return nil
 }
 
 type list struct {
@@ -236,4 +246,10 @@ func (l *list) FindIndex(pred func(interface{}) bool) int {
 		curr = tail.(*list)
 		idx += 1
 	}
+}
+
+// Map applies the function to each entry in the list and returns the resulting
+// slice.
+func (l *list) Map(f func(interface{}) interface{}) []interface{} {
+	return append(l.tail.Map(f), f(l.head))
 }

--- a/list/persistent_test.go
+++ b/list/persistent_test.go
@@ -276,3 +276,14 @@ func TestLength(t *testing.T) {
 	l = l.Add("bar").Add("baz")
 	assert.Equal(uint(3), l.Length())
 }
+
+func TestMap(t *testing.T) {
+	assert := assert.New(t)
+	f := func(x interface{}) interface{} {
+		return x.(int) * x.(int)
+	}
+	assert.Nil(Empty.Map(f))
+
+	l := Empty.Add(1).Add(2).Add(3).Add(4)
+	assert.Equal([]interface{}{1, 4, 9, 16}, l.Map(f))
+}

--- a/trie/ctrie/ctrie.go
+++ b/trie/ctrie/ctrie.go
@@ -350,6 +350,15 @@ func (c *Ctrie) Iterator() <-chan *Entry {
 	return ch
 }
 
+// Size returns the number of keys in the Ctrie.
+func (c *Ctrie) Size() uint {
+	size := uint(0)
+	for _ = range c.Iterator() {
+		size++
+	}
+	return size
+}
+
 func traverse(i *iNode, ch chan<- *Entry) {
 	switch {
 	case i.main.cNode != nil:

--- a/trie/ctrie/ctrie_test.go
+++ b/trie/ctrie/ctrie_test.go
@@ -253,6 +253,36 @@ func TestSnapshot(t *testing.T) {
 	assert.Equal(0, val)
 }
 
+func TestIterator(t *testing.T) {
+	assert := assert.New(t)
+	ctrie := New(nil)
+	for i := 0; i < 10; i++ {
+		ctrie.Insert([]byte(strconv.Itoa(i)), i)
+	}
+	expected := map[string]int{
+		"0": 0,
+		"1": 1,
+		"2": 2,
+		"3": 3,
+		"4": 4,
+		"5": 5,
+		"6": 6,
+		"7": 7,
+		"8": 8,
+		"9": 9,
+	}
+
+	count := 0
+	for entry := range ctrie.Iterator() {
+		exp, ok := expected[string(entry.Key)]
+		if assert.True(ok) {
+			assert.Equal(exp, entry.Value)
+		}
+		count++
+	}
+	assert.Equal(len(expected), count)
+}
+
 func BenchmarkInsert(b *testing.B) {
 	ctrie := New(nil)
 	b.ResetTimer()

--- a/trie/ctrie/ctrie_test.go
+++ b/trie/ctrie/ctrie_test.go
@@ -273,7 +273,7 @@ func TestIterator(t *testing.T) {
 	}
 
 	count := 0
-	for entry := range ctrie.Iterator() {
+	for entry := range ctrie.Iterator(nil) {
 		exp, ok := expected[string(entry.Key)]
 		if assert.True(ok) {
 			assert.Equal(exp, entry.Value)
@@ -281,6 +281,18 @@ func TestIterator(t *testing.T) {
 		count++
 	}
 	assert.Equal(len(expected), count)
+
+	// Closing cancel channel should close iterator channel.
+	cancel := make(chan struct{})
+	iter := ctrie.Iterator(cancel)
+	entry := <-iter
+	exp, ok := expected[string(entry.Key)]
+	if assert.True(ok) {
+		assert.Equal(exp, entry.Value)
+	}
+	close(cancel)
+	_, ok = <-iter
+	assert.False(ok)
 }
 
 func TestSize(t *testing.T) {

--- a/trie/ctrie/ctrie_test.go
+++ b/trie/ctrie/ctrie_test.go
@@ -291,6 +291,21 @@ func TestSize(t *testing.T) {
 	assert.Equal(t, uint(10), ctrie.Size())
 }
 
+func TestClear(t *testing.T) {
+	assert := assert.New(t)
+	ctrie := New(nil)
+	for i := 0; i < 10; i++ {
+		ctrie.Insert([]byte(strconv.Itoa(i)), i)
+	}
+	assert.Equal(uint(10), ctrie.Size())
+	snapshot := ctrie.Snapshot()
+
+	ctrie.Clear()
+
+	assert.Equal(uint(0), ctrie.Size())
+	assert.Equal(uint(10), snapshot.Size())
+}
+
 func BenchmarkInsert(b *testing.B) {
 	ctrie := New(nil)
 	b.ResetTimer()

--- a/trie/ctrie/ctrie_test.go
+++ b/trie/ctrie/ctrie_test.go
@@ -283,6 +283,14 @@ func TestIterator(t *testing.T) {
 	assert.Equal(len(expected), count)
 }
 
+func TestSize(t *testing.T) {
+	ctrie := New(nil)
+	for i := 0; i < 10; i++ {
+		ctrie.Insert([]byte(strconv.Itoa(i)), i)
+	}
+	assert.Equal(t, uint(10), ctrie.Size())
+}
+
 func BenchmarkInsert(b *testing.B) {
 	ctrie := New(nil)
 	b.ResetTimer()


### PR DESCRIPTION
Adds `Iterator`, `Size`, and `Clear` operations to the Ctrie. Also adds a `Map` function to the persistent list.

@dustinhiatt-wf @alexandercampbell-wf @stevenosborne-wf @beaulyddon-wf @rosshendrickson-wf @tannermiller-wf 