### PR TITLE
mock: Bring mock.RangeTree into go-datastructures

### DIFF
--- a/mock/rangetree.go
+++ b/mock/rangetree.go
@@ -1,0 +1,52 @@
+package mock
+
+import (
+	"github.com/stretchr/testify/mock"
+
+	"github.com/Workiva/go-datastructures/rangetree"
+)
+
+type RangeTree struct {
+	mock.Mock
+}
+
+var _ rangetree.RangeTree = new(RangeTree)
+
+func (m *RangeTree) Add(entries ...rangetree.Entry) rangetree.Entries {
+	args := m.Called(entries)
+	ifc := args.Get(0)
+	if ifc == nil {
+		return nil
+	}
+
+	return ifc.(rangetree.Entries)
+}
+
+func (m *RangeTree) Len() uint64 {
+	return m.Called().Get(0).(uint64)
+}
+
+func (m *RangeTree) Delete(entries ...rangetree.Entry) rangetree.Entries {
+	return m.Called(entries).Get(0).(rangetree.Entries)
+}
+
+func (m *RangeTree) Query(interval rangetree.Interval) rangetree.Entries {
+	args := m.Called(interval)
+	ifc := args.Get(0)
+	if ifc == nil {
+		return nil
+	}
+
+	return ifc.(rangetree.Entries)
+}
+
+func (m *RangeTree) InsertAtDimension(dimension uint64, index,
+	number int64) (rangetree.Entries, rangetree.Entries) {
+
+	args := m.Called(dimension, index, number)
+	return args.Get(0).(rangetree.Entries), args.Get(1).(rangetree.Entries)
+}
+
+func (m *RangeTree) Apply(interval rangetree.Interval, fn func(rangetree.Entry) bool) {
+	m.Called(interval, fn)
+}


### PR DESCRIPTION
### Code Review

This change is a step towards making go-datastructures responsible for its own mocks. I'm trying to consolidate the mocks so there is only one mock object for each interface, and the mocks exist in the same repository as the interface.

This will enforce keeping the mock and interface in sync and ease some of the dependency pain.

### Reviewers

@dustinhiatt-wf @rosshendrickson-wf @beaulyddon-wf @ericolson-wf @tylertreat-wf @stevenosborne-wf @matthinrichsen-wf @seanstrickland-wf @tannermiller-wf 