### PR TITLE
Queue poll

### DIFF
--- a/queue/error.go
+++ b/queue/error.go
@@ -18,4 +18,11 @@ package queue
 
 import "errors"
 
-var disposedError = errors.New(`Queue has been disposed.`)
+var (
+	// ErrDisposed is returned when an operation is performed on a disposed
+	// queue.
+	ErrDisposed = errors.New(`Queue has been disposed.`)
+
+	// ErrTimeout is returned when an applicable queue operation times out.
+	ErrTimeout = errors.New(`Poll timed out.`)
+)

--- a/queue/error.go
+++ b/queue/error.go
@@ -21,8 +21,8 @@ import "errors"
 var (
 	// ErrDisposed is returned when an operation is performed on a disposed
 	// queue.
-	ErrDisposed = errors.New(`Queue has been disposed.`)
+	ErrDisposed = errors.New(`queue: disposed`)
 
 	// ErrTimeout is returned when an applicable queue operation times out.
-	ErrTimeout = errors.New(`Poll timed out.`)
+	ErrTimeout = errors.New(`queue: poll timed out`)
 )

--- a/queue/priority_queue_test.go
+++ b/queue/priority_queue_test.go
@@ -193,7 +193,7 @@ func TestEmptyPriorityGetWithDispose(t *testing.T) {
 
 	wg.Wait()
 
-	assert.IsType(t, disposedError, err)
+	assert.IsType(t, ErrDisposed, err)
 }
 
 func TestPriorityGetPutDisposed(t *testing.T) {
@@ -201,10 +201,10 @@ func TestPriorityGetPutDisposed(t *testing.T) {
 	q.Dispose()
 
 	_, err := q.Get(1)
-	assert.IsType(t, disposedError, err)
+	assert.IsType(t, ErrDisposed, err)
 
 	err = q.Put(mockItem(1))
-	assert.IsType(t, disposedError, err)
+	assert.IsType(t, ErrDisposed, err)
 }
 
 func BenchmarkPriorityQueue(b *testing.B) {

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -165,7 +165,6 @@ func (q *Queue) Put(items ...interface{}) error {
 			sema.response.Wait()
 		default:
 			// This semaphore timed out.
-			sema.response.Done()
 		}
 		if len(q.items) == 0 {
 			break

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -160,8 +160,13 @@ func (q *Queue) Put(items ...interface{}) error {
 			break
 		}
 		sema.response.Add(1)
-		sema.ready <- true
-		sema.response.Wait()
+		select {
+		case sema.ready <- true:
+			sema.response.Wait()
+		default:
+			// This semaphore timed out.
+			sema.response.Done()
+		}
 		if len(q.items) == 0 {
 			break
 		}

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -126,7 +126,7 @@ type sema struct {
 
 func newSema() *sema {
 	return &sema{
-		ready:    make(chan bool),
+		ready:    make(chan bool, 1),
 		response: &sync.WaitGroup{},
 	}
 }

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -55,6 +55,7 @@ import (
 	"runtime"
 	"sync"
 	"sync/atomic"
+	"time"
 )
 
 type waiters []*sema
@@ -119,13 +120,13 @@ func (items *items) getUntil(checker func(item interface{}) bool) []interface{} 
 }
 
 type sema struct {
-	wg       *sync.WaitGroup
+	ready    chan bool
 	response *sync.WaitGroup
 }
 
 func newSema() *sema {
 	return &sema{
-		wg:       &sync.WaitGroup{},
+		ready:    make(chan bool),
 		response: &sync.WaitGroup{},
 	}
 }
@@ -149,7 +150,7 @@ func (q *Queue) Put(items ...interface{}) error {
 
 	if q.disposed {
 		q.lock.Unlock()
-		return disposedError
+		return ErrDisposed
 	}
 
 	q.items = append(q.items, items...)
@@ -159,7 +160,7 @@ func (q *Queue) Put(items ...interface{}) error {
 			break
 		}
 		sema.response.Add(1)
-		sema.wg.Done()
+		sema.ready <- true
 		sema.response.Wait()
 		if len(q.items) == 0 {
 			break
@@ -175,6 +176,15 @@ func (q *Queue) Put(items ...interface{}) error {
 // parameter.  If no items are in the queue, this method will pause
 // until items are added to the queue.
 func (q *Queue) Get(number int64) ([]interface{}, error) {
+	return q.Poll(number, 0)
+}
+
+// Poll retrieves items from the queue.  If there are some items in the queue,
+// Poll will return a number UP TO the number passed in as a parameter.  If no
+// items are in the queue, this method will pause until items are added to the
+// queue or the provided timeout is reached.  A non-positive timeout will block
+// until items are added.  If a timeout occurs, ErrTimeout is returned.
+func (q *Queue) Poll(number int64, timeout time.Duration) ([]interface{}, error) {
 	if number < 1 {
 		// thanks again go
 		return []interface{}{}, nil
@@ -184,7 +194,7 @@ func (q *Queue) Get(number int64) ([]interface{}, error) {
 
 	if q.disposed {
 		q.lock.Unlock()
-		return nil, disposedError
+		return nil, ErrDisposed
 	}
 
 	var items []interface{}
@@ -192,17 +202,24 @@ func (q *Queue) Get(number int64) ([]interface{}, error) {
 	if len(q.items) == 0 {
 		sema := newSema()
 		q.waiters.put(sema)
-		sema.wg.Add(1)
 		q.lock.Unlock()
 
-		sema.wg.Wait()
-		// we are now inside the put's lock
-		if q.disposed {
-			return nil, disposedError
+		var timeoutC <-chan time.Time
+		if timeout > 0 {
+			timeoutC = time.After(timeout)
 		}
-		items = q.items.get(number)
-		sema.response.Done()
-		return items, nil
+		select {
+		case <-sema.ready:
+			// we are now inside the put's lock
+			if q.disposed {
+				return nil, ErrDisposed
+			}
+			items = q.items.get(number)
+			sema.response.Done()
+			return items, nil
+		case <-timeoutC:
+			return nil, ErrTimeout
+		}
 	}
 
 	items = q.items.get(number)
@@ -222,7 +239,7 @@ func (q *Queue) TakeUntil(checker func(item interface{}) bool) ([]interface{}, e
 
 	if q.disposed {
 		q.lock.Unlock()
-		return nil, disposedError
+		return nil, ErrDisposed
 	}
 
 	result := q.items.getUntil(checker)
@@ -264,7 +281,7 @@ func (q *Queue) Dispose() {
 	q.disposed = true
 	for _, waiter := range q.waiters {
 		waiter.response.Add(1)
-		waiter.wg.Done()
+		waiter.ready <- true
 	}
 
 	q.items = nil

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -189,7 +189,7 @@ func TestEmptyGetWithDispose(t *testing.T) {
 
 	wg.Wait()
 
-	assert.IsType(t, disposedError, err)
+	assert.IsType(t, ErrDisposed, err)
 }
 
 func TestGetPutDisposed(t *testing.T) {
@@ -198,10 +198,10 @@ func TestGetPutDisposed(t *testing.T) {
 	q.Dispose()
 
 	_, err := q.Get(1)
-	assert.IsType(t, disposedError, err)
+	assert.IsType(t, ErrDisposed, err)
 
 	err = q.Put(`a`)
-	assert.IsType(t, disposedError, err)
+	assert.IsType(t, ErrDisposed, err)
 }
 
 func BenchmarkQueue(b *testing.B) {
@@ -289,7 +289,7 @@ func TestTakeUntilOnDisposedQueue(t *testing.T) {
 	})
 
 	assert.Nil(t, result)
-	assert.IsType(t, disposedError, err)
+	assert.IsType(t, ErrDisposed, err)
 }
 
 func TestExecuteInParallel(t *testing.T) {

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -399,6 +399,29 @@ func BenchmarkQueueGet(b *testing.B) {
 	}
 }
 
+func BenchmarkQueuePoll(b *testing.B) {
+	numItems := int64(1000)
+
+	qs := make([]*Queue, 0, b.N)
+
+	for i := 0; i < b.N; i++ {
+		q := New(numItems)
+		for j := int64(0); j < numItems; j++ {
+			q.Put(j)
+		}
+		qs = append(qs, q)
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		q := qs[i]
+		for j := int64(0); j < numItems; j++ {
+			q.Poll(1, time.Millisecond)
+		}
+	}
+}
+
 func BenchmarkExecuteInParallel(b *testing.B) {
 	numItems := int64(1000)
 

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -414,8 +414,7 @@ func BenchmarkQueuePoll(b *testing.B) {
 
 	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
-		q := qs[i]
+	for _, q := range qs {
 		for j := int64(0); j < numItems; j++ {
 			q.Poll(1, time.Millisecond)
 		}

--- a/queue/ring.go
+++ b/queue/ring.go
@@ -78,7 +78,7 @@ func (rb *RingBuffer) Put(item interface{}) error {
 L:
 	for {
 		if atomic.LoadUint64(&rb.disposed) == 1 {
-			return disposedError
+			return ErrDisposed
 		}
 
 		n = rb.nodes[pos&rb.mask]
@@ -118,7 +118,7 @@ func (rb *RingBuffer) Get() (interface{}, error) {
 L:
 	for {
 		if atomic.LoadUint64(&rb.disposed) == 1 {
-			return nil, disposedError
+			return nil, ErrDisposed
 		}
 
 		n = rb.nodes[pos&rb.mask]


### PR DESCRIPTION
This does a few things:
- Add a `Poll` method to `Queue` which allows you to perform a `Get` with a timeout.
- Export `ErrDisposed` to allow users to check error type.
- Export `ErrTimeout` to allow users to check for timeout vs disposal.
- The internal `sema` struct now uses a channel instead of a `sync.WaitGroup` to provide support for timeouts. The effect on performance is negligible (see below).

Before:
```
BenchmarkPriorityQueue   3000000               517 ns/op
BenchmarkQueue  10000000               194 ns/op
BenchmarkChannel         3000000               672 ns/op
BenchmarkQueuePut          10000            141664 ns/op
BenchmarkQueueGet          10000            112553 ns/op
BenchmarkExecuteInParallel         20000             82021 ns/op
BenchmarkRBLifeCycle      500000              3142 ns/op
BenchmarkRBPut  20000000                85.2 ns/op
BenchmarkRBGet  50000000               484 ns/op
```

After:
```
PASS
BenchmarkPriorityQueue   3000000               539 ns/op
BenchmarkQueue  10000000               197 ns/op
BenchmarkChannel         3000000               574 ns/op
BenchmarkQueuePut          10000            125814 ns/op
BenchmarkQueueGet          10000            104068 ns/op
BenchmarkQueuePoll         20000            109937 ns/op
BenchmarkExecuteInParallel         30000             62881 ns/op
BenchmarkRBLifeCycle      500000              3198 ns/op
BenchmarkRBPut  20000000               101 ns/op
BenchmarkRBGet  50000000               473 ns/op
```

@dustinhiatt-wf @alexandercampbell-wf @stevenosborne-wf @beaulyddon-wf @tannermiller-wf