### PR TITLE
Batcher: Flushing

### DIFF
--- a/batcher/batcher.go
+++ b/batcher/batcher.go
@@ -34,8 +34,9 @@ type Batcher interface {
 	// Flush forcibly completes the batch currently being built
 	Flush() error
 
-	// Dispose will dispose of the batcher. Any calls to Put or Get
-	// will return errors.
+	// Dispose will dispose of the batcher. Any calls to Put or Flush
+	// will return ErrDisposed, calls to Get will return an error iff
+	// there are no more ready batches.
 	Dispose()
 
 	// IsDisposed will determine if the batcher is disposed
@@ -145,8 +146,9 @@ func (b *basicBatcher) Flush() error {
 	return nil
 }
 
-// Dispose will dispose of the batcher. Any calls to Put or Get
-// will return errors.
+// Dispose will dispose of the batcher. Any calls to Put or Flush
+// will return ErrDisposed, calls to Get will return an error iff
+// there are no more ready batches.
 func (b *basicBatcher) Dispose() {
 	b.lock.Lock()
 	if b.disposed {

--- a/mock/batcher.go
+++ b/mock/batcher.go
@@ -1,8 +1,28 @@
+/*
+Copyright 2015 Workiva, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package mock
 
 import (
 	"github.com/stretchr/testify/mock"
+
+	"github.com/Workiva/go-datastructures/batcher"
 )
+
+var _ batcher.Batcher = new(Batcher)
 
 type Batcher struct {
 	mock.Mock
@@ -22,6 +42,16 @@ func (m *Batcher) Get() ([]interface{}, error) {
 	return args.Get(0).([]interface{}), args.Error(1)
 }
 
+func (m *Batcher) Flush() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
 func (m *Batcher) Dispose() {
 	m.Called()
+}
+
+func (m *Batcher) IsDisposed() bool {
+	args := m.Called()
+	return args.Bool(0)
 }


### PR DESCRIPTION
Added a flush function to forcibly complete a batch and made Dispose() automatically flush the current batch before disposing. I also changed Get() to return a disposed error iff the batcher is disposed and there are no more ready batches. Added a few extra checks to prevent possible problems.

@tylertreat-wf @stevenosborne-wf @matthewgardner-wf @dustinhiatt-wf @alexandercampbell-wf 