### PR TITLE
Implement heap-based priority queue

### DIFF
--- a/queue/priority_queue.go
+++ b/queue/priority_queue.go
@@ -49,7 +49,7 @@ func (items *priorityItems) pop() Item {
 	// Move last leaf to root, and 'pop' the last item.
 	items.swap(size-1, 0)
 	item := (*items)[size-1] // Item to return.
-	*items = (*items)[:size-1]
+	(*items)[size-1], *items = nil, (*items)[:size-1]
 
 	// 'Bubble down' to restore heap property.
 	index := 0

--- a/queue/priority_queue.go
+++ b/queue/priority_queue.go
@@ -107,7 +107,7 @@ func (items *priorityItems) push(item Item) {
 type PriorityQueue struct {
 	waiters     waiters
 	items       priorityItems
-	itemMap     map[Item]bool
+	itemMap     map[Item]struct{}
 	lock        sync.Mutex
 	disposeLock sync.Mutex
 	disposed    bool
@@ -126,8 +126,8 @@ func (pq *PriorityQueue) Put(items ...Item) error {
 	}
 
 	for _, item := range items {
-		if ok := pq.itemMap[item]; !ok {
-			pq.itemMap[item] = true
+		if _, ok := pq.itemMap[item]; !ok {
+			pq.itemMap[item] = struct{}{}
 			pq.items.push(item)
 		}
 	}
@@ -170,7 +170,7 @@ func (pq *PriorityQueue) Get(number int) ([]Item, error) {
 	// Remove references to popped items.
 	deleteItems := func(items []Item) {
 		for _, item := range items {
-			pq.itemMap[item] = false
+			delete(pq.itemMap, item)
 		}
 	}
 
@@ -257,6 +257,6 @@ func (pq *PriorityQueue) Dispose() {
 func NewPriorityQueue(hint int) *PriorityQueue {
 	return &PriorityQueue{
 		items:   make(priorityItems, 0, hint),
-		itemMap: make(map[Item]bool, hint),
+		itemMap: make(map[Item]struct{}, hint),
 	}
 }

--- a/queue/priority_queue.go
+++ b/queue/priority_queue.go
@@ -166,11 +166,13 @@ func (pq *PriorityQueue) Get(number int) ([]Item, error) {
 	}
 
 	var items []Item
-	defer func() {
+
+	// Remove references to popped items.
+	deleteItems := func(items []Item) {
 		for _, item := range items {
 			pq.itemMap[item] = false
 		}
-	}()
+	}
 
 	if len(pq.items) == 0 {
 		sema := newSema()
@@ -186,11 +188,13 @@ func (pq *PriorityQueue) Get(number int) ([]Item, error) {
 		pq.disposeLock.Unlock()
 
 		items = pq.items.get(number)
+		deleteItems(items)
 		sema.response.Done()
 		return items, nil
 	}
 
 	items = pq.items.get(number)
+	deleteItems(items)
 	pq.lock.Unlock()
 	return items, nil
 }


### PR DESCRIPTION
This change provides *O(log n)* performance for inserts and removals. The exported interfaces remain intact, only internal implementation has been modified.

Changes:

* Maintain heap property on item update/retrieval
* Avoid duplicates with a map[Item]bool variable
* Use push() and pop() naming for internal operations