### PR TITLE
Add support for duplicated items in PriorityQueue

### DIFF
--- a/queue/priority_queue.go
+++ b/queue/priority_queue.go
@@ -258,16 +258,11 @@ func (pq *PriorityQueue) Dispose() {
 	pq.waiters = nil
 }
 
-// AllowDuplicates determines whether the queue supports
-// duplicated items. This setting is false by default.
-func (pq *PriorityQueue) AllowDuplicates(allow bool) {
-	pq.allowDuplicates = allow
-}
-
 // NewPriorityQueue is the constructor for a priority queue.
-func NewPriorityQueue(hint int) *PriorityQueue {
+func NewPriorityQueue(hint int, allowDuplicates bool) *PriorityQueue {
 	return &PriorityQueue{
-		items:   make(priorityItems, 0, hint),
-		itemMap: make(map[Item]struct{}, hint),
+		items:           make(priorityItems, 0, hint),
+		itemMap:         make(map[Item]struct{}, hint),
+		allowDuplicates: allowDuplicates,
 	}
 }

--- a/queue/priority_queue_test.go
+++ b/queue/priority_queue_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestPriorityPut(t *testing.T) {
-	q := NewPriorityQueue(1)
+	q := NewPriorityQueue(1, false)
 
 	q.Put(mockItem(2))
 
@@ -41,7 +41,7 @@ func TestPriorityPut(t *testing.T) {
 }
 
 func TestPriorityGet(t *testing.T) {
-	q := NewPriorityQueue(1)
+	q := NewPriorityQueue(1, false)
 
 	q.Put(mockItem(2))
 	result, err := q.Get(2)
@@ -84,7 +84,7 @@ func TestPriorityGet(t *testing.T) {
 }
 
 func TestAddEmptyPriorityPut(t *testing.T) {
-	q := NewPriorityQueue(1)
+	q := NewPriorityQueue(1, false)
 
 	q.Put()
 
@@ -92,7 +92,7 @@ func TestAddEmptyPriorityPut(t *testing.T) {
 }
 
 func TestPriorityGetNonPositiveNumber(t *testing.T) {
-	q := NewPriorityQueue(1)
+	q := NewPriorityQueue(1, false)
 
 	q.Put(mockItem(1))
 
@@ -112,7 +112,7 @@ func TestPriorityGetNonPositiveNumber(t *testing.T) {
 }
 
 func TestPriorityEmpty(t *testing.T) {
-	q := NewPriorityQueue(1)
+	q := NewPriorityQueue(1, false)
 	assert.True(t, q.Empty())
 
 	q.Put(mockItem(1))
@@ -121,7 +121,7 @@ func TestPriorityEmpty(t *testing.T) {
 }
 
 func TestPriorityGetEmpty(t *testing.T) {
-	q := NewPriorityQueue(1)
+	q := NewPriorityQueue(1, false)
 
 	go func() {
 		q.Put(mockItem(1))
@@ -139,7 +139,7 @@ func TestPriorityGetEmpty(t *testing.T) {
 }
 
 func TestMultiplePriorityGetEmpty(t *testing.T) {
-	q := NewPriorityQueue(1)
+	q := NewPriorityQueue(1, false)
 	var wg sync.WaitGroup
 	wg.Add(2)
 	results := make([][]Item, 2)
@@ -175,7 +175,7 @@ func TestMultiplePriorityGetEmpty(t *testing.T) {
 }
 
 func TestEmptyPriorityGetWithDispose(t *testing.T) {
-	q := NewPriorityQueue(1)
+	q := NewPriorityQueue(1, false)
 	var wg sync.WaitGroup
 	wg.Add(1)
 
@@ -197,7 +197,7 @@ func TestEmptyPriorityGetWithDispose(t *testing.T) {
 }
 
 func TestPriorityGetPutDisposed(t *testing.T) {
-	q := NewPriorityQueue(1)
+	q := NewPriorityQueue(1, false)
 	q.Dispose()
 
 	_, err := q.Get(1)
@@ -208,7 +208,7 @@ func TestPriorityGetPutDisposed(t *testing.T) {
 }
 
 func BenchmarkPriorityQueue(b *testing.B) {
-	q := NewPriorityQueue(b.N)
+	q := NewPriorityQueue(b.N, false)
 	var wg sync.WaitGroup
 	wg.Add(1)
 	i := 0
@@ -232,14 +232,14 @@ func BenchmarkPriorityQueue(b *testing.B) {
 }
 
 func TestPriorityPeek(t *testing.T) {
-	q := NewPriorityQueue(1)
+	q := NewPriorityQueue(1, false)
 	q.Put(mockItem(1))
 
 	assert.Equal(t, mockItem(1), q.Peek())
 }
 
 func TestInsertDuplicate(t *testing.T) {
-	q := NewPriorityQueue(1)
+	q := NewPriorityQueue(1, false)
 	q.Put(mockItem(1))
 	q.Put(mockItem(1))
 
@@ -247,8 +247,7 @@ func TestInsertDuplicate(t *testing.T) {
 }
 
 func TestAllowDuplicates(t *testing.T) {
-	q := NewPriorityQueue(2)
-	q.AllowDuplicates(true)
+	q := NewPriorityQueue(2, true)
 	q.Put(mockItem(1))
 	q.Put(mockItem(1))
 

--- a/queue/priority_queue_test.go
+++ b/queue/priority_queue_test.go
@@ -245,3 +245,12 @@ func TestInsertDuplicate(t *testing.T) {
 
 	assert.Equal(t, 1, q.Len())
 }
+
+func TestAllowDuplicates(t *testing.T) {
+	q := NewPriorityQueue(2)
+	q.AllowDuplicates(true)
+	q.Put(mockItem(1))
+	q.Put(mockItem(1))
+
+	assert.Equal(t, 2, q.Len())
+}


### PR DESCRIPTION
Changes:

* Implement 'allowDuplicates' flag, while maintaining backwards compatibility.
* Add unit test.

Current implementation includes an easy way of enabling duplicates, but I'm not 100% sure this is the best approach, since the flag can be arbitrarily updated at any time (regardless of existing items and/or previous state of the flag). 

Perhaps it's more sensible to provide an `allowDuplicates()` method for activating the flag without passing the `bool` value, making the variable immutable from this point on. This would be less flexible, but overall more robust probably. Opinions?