### PR TITLE
Avoid deadlock between Put and Get

### DIFF
--- a/batcher/batcher.go
+++ b/batcher/batcher.go
@@ -83,7 +83,8 @@ func New(maxTime time.Duration, maxItems, maxBytes, queueLen uint, calculate Cal
 	}, nil
 }
 
-// Put adds items to the batcher.
+// Put adds items to the batcher. If Put is continually called without calls to
+// Get, an unbounded number of go-routines will be generated.
 func (b *basicBatcher) Put(item interface{}) error {
 	b.lock.Lock()
 	if b.disposed {
@@ -104,7 +105,9 @@ func (b *basicBatcher) Put(item interface{}) error {
 }
 
 // Get retrieves a batch from the batcher. This call will block until
-// one of the conditions for a "complete" batch is reached.
+// one of the conditions for a "complete" batch is reached. If Put is
+// continually called without calls to Get, an unbounded number of
+// go-routines will be generated.
 func (b *basicBatcher) Get() ([]interface{}, error) {
 	// Don't check disposed yet so any items remaining in the queue
 	// will be returned properly.
@@ -158,6 +161,17 @@ func (b *basicBatcher) Dispose() {
 	b.flush()
 	b.disposed = true
 	b.items = nil
+
+	// Drain the batch channel and all routines waiting to put on the channel
+DrainLoop:
+	for {
+		select {
+		case <-b.batchChan:
+		case <-time.After(5 * time.Millisecond):
+			break DrainLoop
+		}
+	}
+
 	close(b.batchChan)
 	b.lock.Unlock()
 }
@@ -173,7 +187,13 @@ func (b *basicBatcher) IsDisposed() bool {
 // flush adds the batch currently being built to the queue of completed batches.
 // flush is not threadsafe, so should be synchronized externally.
 func (b *basicBatcher) flush() {
-	b.batchChan <- b.items
+	// Note: This needs to be in a go-routine to avoid locking out gets when
+	// the batch channel is full.
+	cpItems := make([]interface{}, len(b.items))
+	for i, val := range b.items {
+		cpItems[i] = val
+	}
+	go func() { b.batchChan <- cpItems }()
 	b.items = make([]interface{}, 0, b.maxItems)
 	b.availableBytes = 0
 }

--- a/batcher/batcher.go
+++ b/batcher/batcher.go
@@ -167,7 +167,7 @@ func (b *basicBatcher) Dispose() {
 	b.items = nil
 
 	// Drain the batch channel and all routines waiting to put on the channel
-	for atomic.LoadInt32(&b.waiting) > 0 {
+	for len(b.batchChan) > 0 || atomic.LoadInt32(&b.waiting) > 0 {
 		<-b.batchChan
 	}
 	close(b.batchChan)

--- a/batcher/batcher.go
+++ b/batcher/batcher.go
@@ -19,6 +19,7 @@ package batcher
 import (
 	"errors"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -59,6 +60,7 @@ type basicBatcher struct {
 	lock           sync.RWMutex
 	batchChan      chan []interface{}
 	availableBytes uint
+	waiting        int32
 }
 
 // New creates a new Batcher using the provided arguments.
@@ -85,6 +87,7 @@ func New(maxTime time.Duration, maxItems, maxBytes, queueLen uint, calculate Cal
 
 // Put adds items to the batcher. If Put is continually called without calls to
 // Get, an unbounded number of go-routines will be generated.
+// Note: there is no order guarantee for items entering/leaving the batcher.
 func (b *basicBatcher) Put(item interface{}) error {
 	b.lock.Lock()
 	if b.disposed {
@@ -108,6 +111,7 @@ func (b *basicBatcher) Put(item interface{}) error {
 // one of the conditions for a "complete" batch is reached. If Put is
 // continually called without calls to Get, an unbounded number of
 // go-routines will be generated.
+// Note: there is no order guarantee for items entering/leaving the batcher.
 func (b *basicBatcher) Get() ([]interface{}, error) {
 	// Don't check disposed yet so any items remaining in the queue
 	// will be returned properly.
@@ -163,15 +167,9 @@ func (b *basicBatcher) Dispose() {
 	b.items = nil
 
 	// Drain the batch channel and all routines waiting to put on the channel
-DrainLoop:
-	for {
-		select {
-		case <-b.batchChan:
-		case <-time.After(5 * time.Millisecond):
-			break DrainLoop
-		}
+	for atomic.LoadInt32(&b.waiting) > 0 {
+		<-b.batchChan
 	}
-
 	close(b.batchChan)
 	b.lock.Unlock()
 }
@@ -193,7 +191,13 @@ func (b *basicBatcher) flush() {
 	for i, val := range b.items {
 		cpItems[i] = val
 	}
-	go func() { b.batchChan <- cpItems }()
+	// Signal one more waiter for the batch channel
+	atomic.AddInt32(&b.waiting, 1)
+	// Don't block on the channel put
+	go func() {
+		b.batchChan <- cpItems
+		atomic.AddInt32(&b.waiting, -1)
+	}()
 	b.items = make([]interface{}, 0, b.maxItems)
 	b.availableBytes = 0
 }

--- a/batcher/batcher_test.go
+++ b/batcher/batcher_test.go
@@ -137,7 +137,7 @@ func TestMultiConsumer(t *testing.T) {
 
 func TestDispose(t *testing.T) {
 	assert := assert.New(t)
-	b, err := New(1, 2, 100000, 10, func(str interface{}) uint {
+	b, err := New(1, 2, 100000, 2, func(str interface{}) uint {
 		return uint(len(str.(string)))
 	})
 	assert.Nil(err)
@@ -157,12 +157,18 @@ func TestDispose(t *testing.T) {
 	assert.Nil(err)
 
 	b.Put("d")
+	b.Put("e")
+	b.Put("f")
+	b.Put("g")
+	b.Put("h")
+	b.Put("i")
+
 	b.Dispose()
 
 	_, err = b.Get()
 	assert.Equal(ErrDisposed, err)
 
-	assert.Equal(ErrDisposed, b.Put("e"))
+	assert.Equal(ErrDisposed, b.Put("j"))
 	assert.Equal(ErrDisposed, b.Flush())
 
 }

--- a/batcher/batcher_test.go
+++ b/batcher/batcher_test.go
@@ -36,11 +36,9 @@ func TestMaxItems(t *testing.T) {
 	})
 	assert.Nil(err)
 
-	go func() {
-		for i := 0; i < 1000; i++ {
-			assert.Nil(b.Put("foo bar baz"))
-		}
-	}()
+	for i := 0; i < 1000; i++ {
+		assert.Nil(b.Put("foo bar baz"))
+	}
 
 	batch, err := b.Get()
 	assert.Len(batch, 100)
@@ -139,32 +137,29 @@ func TestMultiConsumer(t *testing.T) {
 
 func TestDispose(t *testing.T) {
 	assert := assert.New(t)
-	b, err := New(0, 2, 100000, 10, func(str interface{}) uint {
+	b, err := New(1, 2, 100000, 10, func(str interface{}) uint {
 		return uint(len(str.(string)))
 	})
 	assert.Nil(err)
 	b.Put("a")
 	b.Put("b")
 	b.Put("c")
-	wait := make(chan bool)
-	go func() {
-		batch1, err := b.Get()
-		assert.Equal([]interface{}{"a", "b"}, batch1)
-		assert.Nil(err)
-		batch2, err := b.Get()
-		assert.Equal([]interface{}{"c"}, batch2)
-		assert.Nil(err)
-		_, err = b.Get()
-		assert.Equal(ErrDisposed, err)
-		wait <- true
-	}()
+
+	batch1, err := b.Get()
+	assert.Equal([]interface{}{"a", "b"}, batch1)
+	assert.Nil(err)
+	batch2, err := b.Get()
+	assert.Equal([]interface{}{"c"}, batch2)
+	assert.Nil(err)
 
 	b.Dispose()
+
+	_, err = b.Get()
+	assert.Equal(ErrDisposed, err)
 
 	assert.Equal(ErrDisposed, b.Put("d"))
 	assert.Equal(ErrDisposed, b.Flush())
 
-	<-wait
 }
 
 func TestIsDisposed(t *testing.T) {

--- a/batcher/batcher_test.go
+++ b/batcher/batcher_test.go
@@ -149,9 +149,15 @@ func TestDispose(t *testing.T) {
 		[]interface{}{"a", "b"},
 		[]interface{}{"c"},
 	}
+
+	// Wait for items to get to the channel
+	for len(b.(*basicBatcher).batchChan) == 0 {
+		time.Sleep(1 * time.Millisecond)
+	}
 	batch1, err := b.Get()
 	assert.Contains(possibleBatches, batch1)
 	assert.Nil(err)
+
 	batch2, err := b.Get()
 	assert.Contains(possibleBatches, batch2)
 	assert.Nil(err)

--- a/batcher/batcher_test.go
+++ b/batcher/batcher_test.go
@@ -145,19 +145,24 @@ func TestDispose(t *testing.T) {
 	b.Put("b")
 	b.Put("c")
 
+	possibleBatches := [][]interface{}{
+		[]interface{}{"a", "b"},
+		[]interface{}{"c"},
+	}
 	batch1, err := b.Get()
-	assert.Equal([]interface{}{"a", "b"}, batch1)
+	assert.Contains(possibleBatches, batch1)
 	assert.Nil(err)
 	batch2, err := b.Get()
-	assert.Equal([]interface{}{"c"}, batch2)
+	assert.Contains(possibleBatches, batch2)
 	assert.Nil(err)
 
+	b.Put("d")
 	b.Dispose()
 
 	_, err = b.Get()
 	assert.Equal(ErrDisposed, err)
 
-	assert.Equal(ErrDisposed, b.Put("d"))
+	assert.Equal(ErrDisposed, b.Put("e"))
 	assert.Equal(ErrDisposed, b.Flush())
 
 }


### PR DESCRIPTION
There is a problem where the batch channel fills up and Puts hold the lock preventing Gets from catching up.

@dustinhiatt-wf @brianshannan-wf @tylertreat @alexandercampbell-wf 