### PR TITLE
Make batcher ordered

### DIFF
--- a/batcher/batcher_test.go
+++ b/batcher/batcher_test.go
@@ -145,29 +145,17 @@ func TestDispose(t *testing.T) {
 	b.Put("b")
 	b.Put("c")
 
-	possibleBatches := [][]interface{}{
-		[]interface{}{"a", "b"},
-		[]interface{}{"c"},
-	}
-
-	// Wait for items to get to the channel
-	for len(b.(*basicBatcher).batchChan) == 0 {
-		time.Sleep(1 * time.Millisecond)
-	}
 	batch1, err := b.Get()
-	assert.Contains(possibleBatches, batch1)
+	assert.Equal([]interface{}{"a", "b"}, batch1)
 	assert.Nil(err)
 
 	batch2, err := b.Get()
-	assert.Contains(possibleBatches, batch2)
+	assert.Equal([]interface{}{"c"}, batch2)
 	assert.Nil(err)
 
 	b.Put("d")
 	b.Put("e")
 	b.Put("f")
-	b.Put("g")
-	b.Put("h")
-	b.Put("i")
 
 	b.Dispose()
 


### PR DESCRIPTION
We now have a use case where we need to support ordering such that if any thread executes
`batcher.Put(item1); batcher.Put(item2);`, a single consumer thread will be guaranteed to see item1 before item2. As go's sync package is awesome and doesn't offer a TryLock function, I implemented a basic mutex using a channel of size 1 to support this, which I believe is correct. If you don't think this is efficient enough, it could be implemented using atomics. I think I avoided potential deadlocks while doing this, but it definitely wouldn't hurt to take a close look.

@tylertreat-wf @stevenosborne-wf @tylerrinnan-wf @dustinhiatt-wf @alexandercampbell-wf 