### PR TITLE
Newer version of bitCount()

### DIFF
--- a/trie/ctrie/ctrie.go
+++ b/trie/ctrie/ctrie.go
@@ -759,11 +759,11 @@ func flagPos(hashcode uint32, lev uint, bmp uint32) (uint32, uint32) {
 }
 
 func bitCount(x uint32) uint32 {
-	x = ((x >> 1) & 0x55555555) + (x & 0x55555555)
+	x -= (x >> 1) & 0x55555555
 	x = ((x >> 2) & 0x33333333) + (x & 0x33333333)
-	x = ((x >> 4) & 0x0f0f0f0f) + (x & 0x0f0f0f0f)
-	x = ((x >> 8) & 0x00ff00ff) + (x & 0x00ff00ff)
-	return ((x >> 16) & 0x0000ffff) + (x & 0x0000ffff)
+	x = ((x >> 4) + x) & 0x0f0f0f0f
+	x *= 0x01010101
+	return x >> 24
 }
 
 // gcas is a generation-compare-and-swap which has semantics similar to RDCSS,


### PR DESCRIPTION
This updates `ctrie.bitCount()` from "version 1" to "version 3" of Jörg Arndt's 32-bit bitcount function (according to http://www.jjj.de/bitwizardry/files/bitcount.h)

I'm quite inexpert at these things, but benchmarking definitely suggests an improvement here (certainly it generates a lot less assembly). Hand-writing the assembly would probably be even better, but I suspect that might be beyond the realm of practical benefits, given that my general benchmarks suggest <4% of overall CPU time is spent here.