### PR TITLE
Make rangetree ranges inclusive.

### DIFF
--- a/rangetree/interface.go
+++ b/rangetree/interface.go
@@ -61,7 +61,7 @@ type RangeTree interface {
 	// a nil is returned for that entry's index in the provided cells.
 	Delete(entries ...Entry) Entries
 	// Query will return a list of entries that fall within
-	// the provided interval.
+	// the provided interval.  The values at dimensions are inclusive.
 	Query(interval Interval) Entries
 	// Apply will call the provided function with each entry that exists
 	// within the provided range, in order.  Return false at any time to

--- a/rangetree/interface.go
+++ b/rangetree/interface.go
@@ -35,7 +35,8 @@ type Entry interface {
 	ValueAtDimension(dimension uint64) int64
 }
 
-// Interval describes the methods required to query the rangetree.
+// Interval describes the methods required to query the rangetree.  Note that
+// all ranges are inclusive.
 type Interval interface {
 	// LowAtDimension returns an integer representing the lower bound
 	// at the requested dimension.

--- a/rangetree/ordered.go
+++ b/rangetree/ordered.go
@@ -85,7 +85,7 @@ func (nodes orderedNodes) apply(low, high int64, fn func(*node) bool) bool {
 	}
 
 	for ; index < len(nodes); index++ {
-		if nodes[index].value >= high {
+		if nodes[index].value > high {
 			break
 		}
 

--- a/rangetree/ordered_test.go
+++ b/rangetree/ordered_test.go
@@ -81,7 +81,7 @@ func TestApply(t *testing.T) {
 
 	results := make(nodes, 0, 2)
 
-	ns.apply(1, 2, func(n *node) bool {
+	ns.apply(1, 1, func(n *node) bool {
 		results = append(results, n)
 		return true
 	})
@@ -90,7 +90,7 @@ func TestApply(t *testing.T) {
 
 	results = results[:0]
 
-	ns.apply(0, 1, func(n *node) bool {
+	ns.apply(0, 0, func(n *node) bool {
 		results = append(results, n)
 		return true
 	})
@@ -98,7 +98,7 @@ func TestApply(t *testing.T) {
 	assert.Len(t, results, 0)
 	results = results[:0]
 
-	ns.apply(2, 4, func(n *node) bool {
+	ns.apply(2, 3, func(n *node) bool {
 		results = append(results, n)
 		return true
 	})

--- a/rangetree/orderedtree.go
+++ b/rangetree/orderedtree.go
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
 package rangetree
 
 func isLastDimension(value, test uint64) bool {

--- a/rangetree/orderedtree_test.go
+++ b/rangetree/orderedtree_test.go
@@ -43,7 +43,7 @@ func TestOTRootAddMultipleDimensions(t *testing.T) {
 
 	assert.Equal(t, uint64(1), tree.Len())
 
-	result := tree.Query(constructMockInterval(dimension{0, 1}, dimension{0, 1}))
+	result := tree.Query(constructMockInterval(dimension{0, 0}, dimension{0, 0}))
 	assert.Equal(t, Entries{entries[0]}, result)
 }
 
@@ -52,7 +52,7 @@ func TestOTMultipleAddMultipleDimensions(t *testing.T) {
 
 	assert.Equal(t, uint64(4), tree.Len())
 
-	result := tree.Query(constructMockInterval(dimension{0, 1}, dimension{0, 1}))
+	result := tree.Query(constructMockInterval(dimension{0, 0}, dimension{0, 0}))
 	assert.Equal(t, Entries{entries[0]}, result)
 
 	result = tree.Query(constructMockInterval(dimension{3, 4}, dimension{3, 4}))
@@ -61,7 +61,7 @@ func TestOTMultipleAddMultipleDimensions(t *testing.T) {
 	result = tree.Query(constructMockInterval(dimension{0, 4}, dimension{0, 4}))
 	assert.Equal(t, entries, result)
 
-	result = tree.Query(constructMockInterval(dimension{1, 3}, dimension{1, 3}))
+	result = tree.Query(constructMockInterval(dimension{1, 2}, dimension{1, 2}))
 	assert.Equal(t, Entries{entries[1], entries[2]}, result)
 
 	result = tree.Query(constructMockInterval(dimension{0, 2}, dimension{10, 20}))
@@ -70,10 +70,10 @@ func TestOTMultipleAddMultipleDimensions(t *testing.T) {
 	result = tree.Query(constructMockInterval(dimension{10, 20}, dimension{0, 2}))
 	assert.Len(t, result, 0)
 
-	result = tree.Query(constructMockInterval(dimension{0, 2}, dimension{0, 1}))
+	result = tree.Query(constructMockInterval(dimension{0, 1}, dimension{0, 0}))
 	assert.Equal(t, Entries{entries[0]}, result)
 
-	result = tree.Query(constructMockInterval(dimension{0, 1}, dimension{0, 2}))
+	result = tree.Query(constructMockInterval(dimension{0, 0}, dimension{0, 1}))
 	assert.Equal(t, Entries{entries[0]}, result)
 }
 
@@ -218,7 +218,7 @@ func TestOTDeleteMultiDimensions(t *testing.T) {
 	result = tree.Query(constructMockInterval(dimension{3, 4}, dimension{3, 4}))
 	assert.Equal(t, Entries{entries[3]}, result)
 
-	result = tree.Query(constructMockInterval(dimension{0, 3}, dimension{0, 3}))
+	result = tree.Query(constructMockInterval(dimension{0, 2}, dimension{0, 2}))
 	assert.Equal(t, Entries{entries[0], entries[1]}, result)
 }
 


### PR DESCRIPTION
Makes rangetree ranges inclusive.  Easier to reason about I think and matches what we are trying to do elsewhere.  This will probably break the older repos, but should be an easy change for @alexandercampbell-wf I think.  

@alexandercampbell-wf @rosshendrickson-wf @ericolson-wf @seanstrickland-wf @matthinrichsen-wf @wesleybalvanz-wf @blakewilson-wf 