### PR TITLE
fixed Queue.Poll() timout bug, Put() would get stuck on leftover sema

### DIFF
--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -85,6 +85,9 @@ func TestGet(t *testing.T) {
 func TestPoll(t *testing.T) {
 	q := New(10)
 
+	// should be able to Poll() before anything is present, without breaking future Puts
+	q.Poll(1, time.Millisecond)
+
 	q.Put(`test`)
 	result, err := q.Poll(2, 0)
 	if !assert.Nil(t, err) {


### PR DESCRIPTION
If you call Poll() and it times out and returns, then a future call to Put() would hang forever, due to a sema that was left behind.