### PR TITLE
Make interval tree inclusive.

### DIFF
--- a/augmentedtree/atree.go
+++ b/augmentedtree/atree.go
@@ -16,10 +16,7 @@ limitations under the License.
 
 package augmentedtree
 
-import (
-	"log"
-	"math"
-)
+import "math"
 
 func intervalOverlaps(n *node, low, high int64, interval Interval, maxDimension uint64) bool {
 	if !overlaps(n.high, high, n.low, low) {
@@ -334,7 +331,6 @@ func (tree *tree) Insert(dimension uint64,
 	modified, deleted := intervalsPool.Get().(Intervals), intervalsPool.Get().(Intervals)
 
 	tree.root.query(math.MinInt64, math.MaxInt64, nil, tree.maxDimension, func(n *node) {
-		log.Printf(`N: %+v`, n)
 		if dimension > 1 {
 			action := insertInterval(dimension, n.interval, index, count)
 			switch action {
@@ -367,8 +363,6 @@ func (tree *tree) Insert(dimension uint64,
 				n.low = index
 			}
 		}
-
-		log.Printf(`N before check: %+v`, n)
 
 		//mod := false
 		if n.high > index {

--- a/augmentedtree/atree.go
+++ b/augmentedtree/atree.go
@@ -364,7 +364,6 @@ func (tree *tree) Insert(dimension uint64,
 			}
 		}
 
-		//mod := false
 		if n.high > index {
 			n.high += count
 			if n.high < index {

--- a/augmentedtree/atree.go
+++ b/augmentedtree/atree.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package augmentedtree
 
-import "math"
+import (
+	"log"
+	"math"
+)
 
 func intervalOverlaps(n *node, low, high int64, interval Interval, maxDimension uint64) bool {
 	if !overlaps(n.high, high, n.low, low) {
@@ -298,7 +301,7 @@ func (tree *tree) delete(iv Interval) {
 // be deleted.  A 0 indicates this interval requires no action.
 func insertInterval(dimension uint64, interval Interval, index, count int64) int {
 	low, high := interval.LowAtDimension(dimension), interval.HighAtDimension(dimension)
-	if index >= high {
+	if index > high {
 		return 0
 	}
 
@@ -331,6 +334,7 @@ func (tree *tree) Insert(dimension uint64,
 	modified, deleted := intervalsPool.Get().(Intervals), intervalsPool.Get().(Intervals)
 
 	tree.root.query(math.MinInt64, math.MaxInt64, nil, tree.maxDimension, func(n *node) {
+		log.Printf(`N: %+v`, n)
 		if dimension > 1 {
 			action := insertInterval(dimension, n.interval, index, count)
 			switch action {
@@ -342,7 +346,7 @@ func (tree *tree) Insert(dimension uint64,
 			return
 		}
 
-		if n.max <= index { // won't change min or max in this case
+		if n.max < index { // won't change min or max in this case
 			return
 		}
 

--- a/augmentedtree/atree.go
+++ b/augmentedtree/atree.go
@@ -16,10 +16,7 @@ limitations under the License.
 
 package augmentedtree
 
-import (
-	"log"
-	"math"
-)
+import "math"
 
 func intervalOverlaps(n *node, low, high int64, interval Interval, maxDimension uint64) bool {
 	if !overlaps(n.high, high, n.low, low) {
@@ -334,7 +331,6 @@ func (tree *tree) Insert(dimension uint64,
 	modified, deleted := intervalsPool.Get().(Intervals), intervalsPool.Get().(Intervals)
 
 	tree.root.query(math.MinInt64, math.MaxInt64, nil, tree.maxDimension, func(n *node) {
-		log.Printf(`N: %+v`, n)
 		if dimension > 1 {
 			action := insertInterval(dimension, n.interval, index, count)
 			switch action {
@@ -350,30 +346,35 @@ func (tree *tree) Insert(dimension uint64,
 			return
 		}
 
+		needsDeletion := false
+
 		n.max += count
 		if n.min >= index {
 			n.min += count
 		}
 
-		mod := false
-		if n.high > index {
-			n.high += count
-			if n.high < index {
-				n.high = index
-			}
-			mod = true
-		}
 		if n.low > index {
 			n.low += count
 			if n.low < index {
 				n.low = index
 			}
-			mod = true
+			//mod = true
 		}
 
-		if n.low >= n.high {
+		//mod := false
+		if n.high > index {
+			n.high += count
+			if n.high < n.low {
+				needsDeletion = true
+			}
+			if n.high < index {
+				n.high = index
+			}
+		}
+
+		if needsDeletion {
 			deleted = append(deleted, n.interval)
-		} else if mod {
+		} else {
 			modified = append(modified, n.interval)
 		}
 	})

--- a/augmentedtree/atree.go
+++ b/augmentedtree/atree.go
@@ -37,7 +37,7 @@ func intervalOverlaps(n *node, low, high int64, interval Interval, maxDimension 
 }
 
 func overlaps(high, otherHigh, low, otherLow int64) bool {
-	return high > otherLow && low < otherHigh
+	return high >= otherLow && low <= otherHigh
 }
 
 // compare returns an int indicating which direction the node

--- a/augmentedtree/atree_test.go
+++ b/augmentedtree/atree_test.go
@@ -305,7 +305,7 @@ func constructSingleDimensionQueryTestTree() (
 
 	it := newTree(1)
 
-	iv1 := constructSingleDimensionInterval(5, 10, 0)
+	iv1 := constructSingleDimensionInterval(6, 10, 0)
 	it.Add(iv1)
 
 	iv2 := constructSingleDimensionInterval(4, 5, 1)
@@ -329,7 +329,7 @@ func TestSimpleQuery(t *testing.T) {
 func TestRightQuery(t *testing.T) {
 	it, iv1, _, iv3 := constructSingleDimensionQueryTestTree()
 
-	result := it.Query(constructSingleDimensionInterval(5, 8, 0))
+	result := it.Query(constructSingleDimensionInterval(6, 8, 0))
 
 	expected := Intervals{iv1, iv3}
 	assert.Equal(t, expected, result)
@@ -356,7 +356,7 @@ func TestMatchingQuery(t *testing.T) {
 func TestNoMatchLeft(t *testing.T) {
 	it, _, _, _ := constructSingleDimensionQueryTestTree()
 
-	result := it.Query(constructSingleDimensionInterval(1, 4, 0))
+	result := it.Query(constructSingleDimensionInterval(1, 3, 0))
 
 	expected := Intervals{}
 	assert.Equal(t, expected, result)
@@ -365,7 +365,7 @@ func TestNoMatchLeft(t *testing.T) {
 func TestNoMatchRight(t *testing.T) {
 	it, _, _, _ := constructSingleDimensionQueryTestTree()
 
-	result := it.Query(constructSingleDimensionInterval(12, 13, 0))
+	result := it.Query(constructSingleDimensionInterval(13, 13, 0))
 
 	expected := Intervals{}
 	assert.Equal(t, expected, result)
@@ -605,7 +605,7 @@ func TestInsertSingleAtDimension(t *testing.T) {
 	assert.Len(t, deleted, 0)
 	assert.Equal(t, ivs[1:], modified)
 
-	result := tree.Query(constructSingleDimensionInterval(10, 20, 0))
+	result := tree.Query(constructSingleDimensionInterval(11, 20, 0))
 	assert.Equal(t, ivs[1:], result)
 	checkRedBlack(t, tree.root, 1)
 
@@ -635,7 +635,7 @@ func TestInsertAtLowestIndex(t *testing.T) {
 	assert.Equal(t, ivs[0:], modified)
 	assert.Len(t, deleted, 0)
 
-	result := tree.Query(constructSingleDimensionInterval(0, 1, 0))
+	result := tree.Query(constructSingleDimensionInterval(0, 0, 0))
 	assert.Len(t, result, 0)
 
 	result = tree.Query(constructSingleDimensionInterval(1, 4, 0))
@@ -654,7 +654,7 @@ func TestDeleteSingleAtDimension(t *testing.T) {
 	assert.Equal(t, ivs[1:], modified)
 	assert.Len(t, deleted, 0)
 
-	result := tree.Query(constructSingleDimensionInterval(10, 20, 0))
+	result := tree.Query(constructSingleDimensionInterval(11, 20, 0))
 	assert.Equal(t, ivs[2:], result)
 
 	result = tree.Query(constructSingleDimensionInterval(9, 20, 0))
@@ -681,7 +681,7 @@ func TestDeleteBelowLowestIndex(t *testing.T) {
 	assert.Equal(t, ivs, modified)
 	assert.Len(t, deleted, 0)
 
-	result := tree.Query(constructSingleDimensionInterval(0, 1, 0))
+	result := tree.Query(constructSingleDimensionInterval(0, 0, 0))
 	assert.Equal(t, ivs[:1], result)
 
 	result = tree.Query(constructSingleDimensionInterval(0, 10, 0))
@@ -699,7 +699,7 @@ func TestInsertDeletesInterval(t *testing.T) {
 	assert.Equal(t, ivs[1:], modified)
 	assert.Equal(t, ivs[:1], deleted)
 
-	result := tree.Query(constructSingleDimensionInterval(2, 10, 0))
+	result := tree.Query(constructSingleDimensionInterval(3, 10, 0))
 	assert.Len(t, result, 0)
 
 	result = tree.Query(constructSingleDimensionInterval(0, 2, 0))

--- a/augmentedtree/atree_test.go
+++ b/augmentedtree/atree_test.go
@@ -601,7 +601,7 @@ func TestAddDeleteDuplicatesRebalanceRandomOrder(t *testing.T) {
 func TestInsertSingleAtDimension(t *testing.T) {
 	tree, ivs := constructSingleDimensionTestTree(3)
 
-	modified, deleted := tree.Insert(1, 10, 1)
+	modified, deleted := tree.Insert(1, 11, 1)
 	assert.Len(t, deleted, 0)
 	assert.Equal(t, ivs[1:], modified)
 
@@ -616,7 +616,7 @@ func TestInsertSingleAtDimension(t *testing.T) {
 func TestInsertMultipleAtDimension(t *testing.T) {
 	tree, ivs := constructSingleDimensionTestTree(3)
 
-	modified, deleted := tree.Insert(1, 10, 2)
+	modified, deleted := tree.Insert(1, 11, 2)
 	assert.Len(t, deleted, 0)
 	assert.Equal(t, ivs[1:], modified)
 
@@ -650,12 +650,12 @@ func TestInsertAtLowestIndex(t *testing.T) {
 func TestDeleteSingleAtDimension(t *testing.T) {
 	tree, ivs := constructSingleDimensionTestTree(3)
 
-	modified, deleted := tree.Insert(1, 10, -1)
+	modified, deleted := tree.Insert(1, 11, -1)
 	assert.Equal(t, ivs[1:], modified)
 	assert.Len(t, deleted, 0)
 
 	result := tree.Query(constructSingleDimensionInterval(11, 20, 0))
-	assert.Equal(t, ivs[2:], result)
+	assert.Equal(t, ivs[1:], result)
 
 	result = tree.Query(constructSingleDimensionInterval(9, 20, 0))
 	assert.Equal(t, ivs, result)
@@ -695,7 +695,7 @@ func TestDeleteBelowLowestIndex(t *testing.T) {
 func TestInsertDeletesInterval(t *testing.T) {
 	tree, ivs := constructSingleDimensionTestTree(3)
 
-	modified, deleted := tree.Insert(1, 0, -10)
+	modified, deleted := tree.Insert(1, 0, -11)
 	assert.Equal(t, ivs[1:], modified)
 	assert.Equal(t, ivs[:1], deleted)
 
@@ -708,7 +708,7 @@ func TestInsertDeletesInterval(t *testing.T) {
 	checkRedBlack(t, tree.root, 1)
 	assert.Equal(t, uint64(2), tree.Len())
 	assert.Equal(t, int64(0), tree.root.min)
-	assert.Equal(t, int64(2), tree.root.max)
+	assert.Equal(t, int64(1), tree.root.max)
 }
 
 func TestDeleteMiddleOfRange(t *testing.T) {

--- a/augmentedtree/interface.go
+++ b/augmentedtree/interface.go
@@ -32,7 +32,10 @@ range handling.
 package augmentedtree
 
 // Interval is the interface that must be implemented by any
-// item added to the interval tree.
+// item added to the interval tree.  This interface is similar to the
+// interval found in the rangetree package and it should be possible
+// for the same struct to implement both interfaces.  Note that ranges
+// here are inclusive.
 type Interval interface {
 	// LowAtDimension returns an integer representing the lower bound
 	// at the requested dimension.

--- a/augmentedtree/multidimensional_test.go
+++ b/augmentedtree/multidimensional_test.go
@@ -130,6 +130,19 @@ func TestAddRebalanceInOrderMultiDimensions(t *testing.T) {
 	assert.Equal(t, uint64(10), it.Len())
 }
 
+func TestInsertAtMax(t *testing.T) {
+	it := newTree(2)
+	iv := constructMultiDimensionInterval(0, &dimension{0, 0}, &dimension{0, 0})
+
+	modified, deleted := it.Insert(1, 0, 1)
+	assert.Empty(t, deleted)
+	assert.Len(t, modified, 1)
+
+	modified, deleted = it.Insert(2, 0, 1)
+	assert.Empty(t, deleted)
+	assert.Len(t, modified, 1)
+}
+
 func TestAddRebalanceReverseOrderMultiDimensions(t *testing.T) {
 	it := newTree(2)
 

--- a/augmentedtree/multidimensional_test.go
+++ b/augmentedtree/multidimensional_test.go
@@ -498,7 +498,7 @@ func TestInsertPositiveMultipleDimensions(t *testing.T) {
 func TestInsertNegativeMultipleDimensions(t *testing.T) {
 	it, iv1, iv2, iv3 := constructMultiDimensionQueryTestTree()
 
-	modified, deleted := it.Insert(2, 4, -1)
+	modified, deleted := it.Insert(2, 4, -2)
 	assert.Equal(t, Intervals{iv1, iv3}, modified)
 	assert.Equal(t, Intervals{iv2}, deleted)
 

--- a/augmentedtree/multidimensional_test.go
+++ b/augmentedtree/multidimensional_test.go
@@ -140,10 +140,9 @@ func TestInsertAtMax(t *testing.T) {
 	assert.Empty(t, deleted)
 	assert.Len(t, modified, 1)
 
-	/*
-		modified, deleted = it.Insert(2, 0, 1)
-		assert.Empty(t, deleted)
-		assert.Len(t, modified, 1)*/
+	modified, deleted = it.Insert(2, 0, 1)
+	assert.Empty(t, deleted)
+	assert.Len(t, modified, 1)
 }
 
 func TestAddRebalanceReverseOrderMultiDimensions(t *testing.T) {

--- a/augmentedtree/multidimensional_test.go
+++ b/augmentedtree/multidimensional_test.go
@@ -134,13 +134,16 @@ func TestInsertAtMax(t *testing.T) {
 	it := newTree(2)
 	iv := constructMultiDimensionInterval(0, &dimension{0, 0}, &dimension{0, 0})
 
+	it.Add(iv)
+
 	modified, deleted := it.Insert(1, 0, 1)
 	assert.Empty(t, deleted)
 	assert.Len(t, modified, 1)
 
-	modified, deleted = it.Insert(2, 0, 1)
-	assert.Empty(t, deleted)
-	assert.Len(t, modified, 1)
+	/*
+		modified, deleted = it.Insert(2, 0, 1)
+		assert.Empty(t, deleted)
+		assert.Len(t, modified, 1)*/
 }
 
 func TestAddRebalanceReverseOrderMultiDimensions(t *testing.T) {

--- a/sort/sort.go
+++ b/sort/sort.go
@@ -70,3 +70,22 @@ func chunk(comparators Comparators, numParts int64) []Comparators {
 	}
 	return parts
 }
+
+func returnInts() []int {
+	numCalls := 10
+	var wg sync.WaitGroup
+	wg.Add(numCalls)
+	ints := make([]int, numCalls)
+
+	for i := 0; i < numCalls; i++ {
+		go func(i int) {
+			result := someRandomDatastoreCall()
+			ints[i] = result
+			wg.Done()
+		}(i)
+	}
+
+	wg.Wait()
+
+	return ints
+}

--- a/sort/sort.go
+++ b/sort/sort.go
@@ -70,22 +70,3 @@ func chunk(comparators Comparators, numParts int64) []Comparators {
 	}
 	return parts
 }
-
-func returnInts() []int {
-	numCalls := 10
-	var wg sync.WaitGroup
-	wg.Add(numCalls)
-	ints := make([]int, numCalls)
-
-	for i := 0; i < numCalls; i++ {
-		go func(i int) {
-			result := someRandomDatastoreCall()
-			ints[i] = result
-			wg.Done()
-		}(i)
-	}
-
-	wg.Wait()
-
-	return ints
-}


### PR DESCRIPTION
This ensures the interval tree interval interface uses inclusive ranges to match the rangetree interval interface.  The same struct should be able to implement both now.

@alexandercampbell-wf @rosshendrickson-wf @ericolson-wf @seanstrickland-wf @matthinrichsen-wf @wesleybalvanz-wf @blakewilson-wf 