### PR TITLE
Ups delta in batcher test case.

### DIFF
--- a/batcher/batcher_test.go
+++ b/batcher/batcher_test.go
@@ -84,7 +84,7 @@ func TestMaxTime(t *testing.T) {
 
 	// This delta is normally 1-3 ms but running tests in CI with -race causes
 	// this to run much slower. For now, just bump up the threshold.
-	assert.InDelta(200, time.Since(before).Seconds()*1000, 50)
+	assert.InDelta(200, time.Since(before).Seconds()*1000, 100)
 	assert.True(len(batch) > 0)
 	assert.Nil(err)
 }


### PR DESCRIPTION
We are still getting failing builds on occasion due to this test and going over the delta.  It'd be nice to not have to rely on timing like this in a test but until that is done this ensures builds will pass.

@brianshannan-wf @alexandercampbell-wf @rosshendrickson-wf @ericolson-wf @seanstrickland-wf @matthinrichsen-wf @wesleybalvanz-wf @blakewilson-wf 