### PR TITLE
Fix deletion on collision.

### DIFF
--- a/hashmap/fastinteger/hashmap.go
+++ b/hashmap/fastinteger/hashmap.go
@@ -77,6 +77,13 @@ func (packets packets) delete(key uint64) bool {
 		return false
 	}
 	packets[i] = nil
+	i = (i + 1) & (uint64(len(packets)) - 1)
+	for packets[i] != nil {
+		p := packets[i]
+		packets[i] = nil
+		packets.set(p)
+		i = (i + 1) & (uint64(len(packets)) - 1)
+	}
 	return true
 }
 

--- a/hashmap/fastinteger/hashmap_test.go
+++ b/hashmap/fastinteger/hashmap_test.go
@@ -121,6 +121,23 @@ func TestDeleteAll(t *testing.T) {
 	}
 }
 
+func TestDeleteCollision(t *testing.T) {
+	// 1, 27, 42 all hash to the same value using our hash function % 32
+	if hash(1)%32 != 12 || hash(27)%32 != 12 || hash(42)%32 != 12 {
+		t.Error("test values don't hash to the same value")
+	}
+
+	m := New(32)
+	m.Set(1, 1)
+	m.Set(27, 27)
+	m.Set(42, 42)
+
+	m.Delete(27)
+	value, ok := m.Get(42)
+	assert.True(t, ok)
+	assert.Equal(t, uint64(42), value)
+}
+
 func BenchmarkInsert(b *testing.B) {
 	numItems := uint64(1000)
 


### PR DESCRIPTION
Fixes hashmap delete case.  Code thanks to mmalone and https://github.com/Workiva/go-datastructures/issues/120.  There are likely better algorithms out there, as mmalone points out, but this at least gets a fix in place while working toward a more performant solution.

@alexandercampbell-wf @rosshendrickson-wf @ericolson-wf @seanstrickland-wf @matthinrichsen-wf @wesleybalvanz-wf @blakewilson-wf 