### PR TITLE
Fix Ctrie snapshotting

### DIFF
--- a/trie/ctrie/ctrie.go
+++ b/trie/ctrie/ctrie.go
@@ -845,7 +845,7 @@ type rdcssDescriptor struct {
 	old       *iNode
 	expected  *mainNode
 	nv        *iNode
-	committed bool
+	committed int32
 }
 
 // readRoot performs a linearizable read of the Ctrie root. This operation is
@@ -878,7 +878,7 @@ func (c *Ctrie) rdcssRoot(old *iNode, expected *mainNode, nv *iNode) bool {
 	}
 	if c.casRoot(old, desc) {
 		c.rdcssComplete(false)
-		return desc.rdcss.committed
+		return atomic.LoadInt32(&desc.rdcss.committed) == 1
 	}
 	return false
 }
@@ -909,7 +909,7 @@ func (c *Ctrie) rdcssComplete(abort bool) *iNode {
 		if oldeMain == exp {
 			// Commit the RDCSS.
 			if c.casRoot(r, nv) {
-				desc.committed = true
+				atomic.StoreInt32(&desc.committed, 1)
 				return nv
 			}
 			continue

--- a/trie/ctrie/ctrie.go
+++ b/trie/ctrie/ctrie.go
@@ -485,7 +485,7 @@ func (c *Ctrie) iinsert(i *iNode, entry *Entry, lev uint, parent *iNode, startGe
 			// If the branch is an I-node, then iinsert is called recursively.
 			in := branch.(*iNode)
 			if startGen == in.gen {
-				return c.iinsert(in, entry, lev+w, i, i.gen)
+				return c.iinsert(in, entry, lev+w, i, startGen)
 			}
 			if gcas(i, main, &mainNode{cNode: cn.renewed(startGen, c)}, c) {
 				return c.iinsert(i, entry, lev, parent, startGen)

--- a/trie/ctrie/ctrie.go
+++ b/trie/ctrie/ctrie.go
@@ -63,8 +63,10 @@ type Ctrie struct {
 }
 
 // generation demarcates Ctrie snapshots. We use a heap-allocated reference
-// instead of an integer to avoid integer overflows.
-type generation struct{}
+// instead of an integer to avoid integer overflows. Struct must have a field
+// on it since two distinct zero-size variables may have the same address in
+// memory.
+type generation struct{ _ int }
 
 // iNode is an indirection node. I-nodes remain present in the Ctrie even as
 // nodes above and below change. Thread-safety is achieved in part by

--- a/trie/ctrie/ctrie.go
+++ b/trie/ctrie/ctrie.go
@@ -322,7 +322,7 @@ func (c *Ctrie) Snapshot() *Ctrie {
 		root := c.readRoot()
 		main := gcasRead(root, c)
 		if c.rdcssRoot(root, main, root.copyToGen(&generation{}, c)) {
-			return newCtrie(root.copyToGen(&generation{}, c), c.hashFactory, c.readOnly)
+			return newCtrie(c.readRoot().copyToGen(&generation{}, c), c.hashFactory, c.readOnly)
 		}
 	}
 }
@@ -337,7 +337,7 @@ func (c *Ctrie) ReadOnlySnapshot() *Ctrie {
 		root := c.readRoot()
 		main := gcasRead(root, c)
 		if c.rdcssRoot(root, main, root.copyToGen(&generation{}, c)) {
-			return newCtrie(root, c.hashFactory, true)
+			return newCtrie(c.readRoot(), c.hashFactory, true)
 		}
 	}
 }

--- a/trie/ctrie/ctrie.go
+++ b/trie/ctrie/ctrie.go
@@ -813,8 +813,8 @@ func gcasComplete(i *iNode, m *mainNode, ctrie *Ctrie) *mainNode {
 			// Signals GCAS failure. Swap old value back into I-node.
 			fn := prev.failed
 			if atomic.CompareAndSwapPointer((*unsafe.Pointer)(unsafe.Pointer(&i.main)),
-				unsafe.Pointer(m), unsafe.Pointer(fn.prev)) {
-				return fn.prev
+				unsafe.Pointer(m), unsafe.Pointer(fn)) {
+				return fn
 			}
 			m = (*mainNode)(atomic.LoadPointer(
 				(*unsafe.Pointer)(unsafe.Pointer(&i.main))))

--- a/trie/ctrie/ctrie_test.go
+++ b/trie/ctrie/ctrie_test.go
@@ -169,6 +169,47 @@ func TestConcurrency(t *testing.T) {
 	wg.Wait()
 }
 
+func TestConcurrency2(t *testing.T) {
+	assert := assert.New(t)
+	ctrie := New(nil)
+	var wg sync.WaitGroup
+	wg.Add(4)
+
+	go func() {
+		for i := 0; i < 10000; i++ {
+			ctrie.Insert([]byte(strconv.Itoa(i)), i)
+		}
+		wg.Done()
+	}()
+
+	go func() {
+		for i := 0; i < 10000; i++ {
+			val, ok := ctrie.Lookup([]byte(strconv.Itoa(i)))
+			if ok {
+				assert.Equal(i, val)
+			}
+		}
+		wg.Done()
+	}()
+
+	go func() {
+		for i := 0; i < 10000; i++ {
+			ctrie.Snapshot()
+		}
+		wg.Done()
+	}()
+
+	go func() {
+		for i := 0; i < 10000; i++ {
+			ctrie.ReadOnlySnapshot()
+		}
+		wg.Done()
+	}()
+
+	wg.Wait()
+	assert.Equal(uint(10000), ctrie.Size())
+}
+
 func TestSnapshot(t *testing.T) {
 	assert := assert.New(t)
 	ctrie := New(nil)


### PR DESCRIPTION
Fixes #122 issues with snapshot concurrency. The main problem was with GCAS, which is used to ensure both the I-node and root generation have not changed. I made an incorrect assumption from Java (where `new Object() != new Object()`). In Go, this is not quite the case: https://play.golang.org/p/BBde4cX1GC. As a result, GCAS always succeeded, despite the root generation changing during a snapshot. These are also problems present in matchbox.

Also fixed some linearization issues in snapshotting and iterators and lastly fixed a race condition in RDCSS.

None of the tests I've run with high concurrency reads, writes, and snapshots with and w/o `-race` have produced any issues.

@dustinhiatt-wf @alexandercampbell-wf @stevenosborne-wf @tylerrinnan-wf @brianshannan-wf 

CC @newhook