### PR TITLE
Fix deletion bug due to incorrect node copy.

### DIFF
--- a/tree/avl/avl.go
+++ b/tree/avl/avl.go
@@ -251,6 +251,7 @@ func (immutable *Immutable) delete(entry Entry) Entry {
 	}
 	it = it.copy() // the node we found needs to be copied
 
+	oldTop := top
 	if it.children[0] == nil || it.children[1] == nil { // need to set children on parent, splicing out
 		dir = intFromBool(it.children[0] == nil)
 		if top != 0 {
@@ -272,6 +273,11 @@ func (immutable *Immutable) delete(entry Entry) Entry {
 		}
 
 		it.entry = heir.entry
+		if oldTop != 0 {
+			cache[oldTop-1].children[dirs[oldTop-1]] = it
+		} else {
+			immutable.root = it
+		}
 		cache[top-1].children[intFromBool(cache[top-1] == it)] = heir.children[1]
 	}
 

--- a/tree/avl/avl_test.go
+++ b/tree/avl/avl_test.go
@@ -295,6 +295,29 @@ func TestAVLDeleteReplay(t *testing.T) {
 	assert.Equal(t, uint64(4), i2.Len())
 }
 
+func TestAVLFails(t *testing.T) {
+	keys := []mockEntry{
+		mockEntry(0),
+		mockEntry(1),
+		mockEntry(3),
+		mockEntry(4),
+		mockEntry(5),
+		mockEntry(6),
+		mockEntry(7),
+		mockEntry(2),
+	}
+	i1 := NewImmutable()
+	for _, k := range keys {
+		i1, _ = i1.Insert(k)
+	}
+
+	for _, k := range keys {
+		var deleted Entries
+		i1, deleted = i1.Delete(k)
+		assert.Equal(t, Entries{k}, deleted)
+	}
+}
+
 func BenchmarkImmutableInsert(b *testing.B) {
 	numItems := b.N
 	sl := NewImmutable()


### PR DESCRIPTION
Implements @newhook's fix for the AVL tree.  Issue can be found here: https://github.com/Workiva/go-datastructures/issues/126

@alexandercampbell-wf @rosshendrickson-wf @ericolson-wf @seanstrickland-wf @matthinrichsen-wf @wesleybalvanz-wf @blakewilson-wf 