### PR TITLE
Dtrie

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,14 @@ Most concurrent data structures do not support snapshots, instead opting for
 locks or requiring a quiescent state. This allows Ctries to have O(1) iterator
 creation and clear operations and O(logn) size retrieval.
 
+#### Dtrie
+
+A persistent hash trie that dynamically expands or shrinks to provide efficient
+memory allocation. Being persistent, the Dtrie is immutable and any modification
+yields a new version of the Dtrie rather than changing the original. Bitmapped
+nodes allow for O(log32(n)) get, remove, and update operations. Insertions are
+O(n) and iteration is O(1).
+
 #### Persistent List
 
 A persistent, immutable linked list. All write operations yield a new, updated
@@ -204,4 +212,3 @@ Requirements to commit here:
 
  - Dustin Hiatt <[dustin.hiatt@workiva.com](mailto:dustin.hiatt@workiva.com)>
  - Alexander Campbell <[alexander.campbell@workiva.com](mailto:alexander.campbell@workiva.com)>
-

--- a/trie/dtrie/dtrie.go
+++ b/trie/dtrie/dtrie.go
@@ -1,0 +1,88 @@
+/*
+Copyright (c) 2016, Theodore Butler
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+// Package dtrie provides an implementation of the dtrie data structure, which
+// is a persistent hash trie that dynamically expands or shrinks to provide
+// efficient memory allocation. This data structure is based on the papers
+// Ideal Hash Trees by Phil Bagwell and Optimizing Hash-Array Mapped Tries for
+// Fast and Lean Immutable JVM Collections by Michael J. Steindorfer and
+// Jurgen J. Vinju
+package dtrie
+
+// Dtrie is a persistent hash trie that dynamically expands or shrinks
+// to provide efficient memory allocation.
+type Dtrie struct {
+	root   *node
+	hasher func(v interface{}) uint32
+}
+
+// New creates an empty DTrie with the given hashing function.
+// If nil is passed in, the default hashing function will be used.
+func New(hasher func(v interface{}) uint32) *Dtrie {
+	if hasher == nil {
+		hasher = defaultHasher
+	}
+	return &Dtrie{
+		root:   emptyNode(0, 32),
+		hasher: hasher,
+	}
+}
+
+// Size returns the number of entries in the Dtrie.
+func (d *Dtrie) Size() (size int) {
+	for range iterate(d.root, nil) {
+		size++
+	}
+	return size
+}
+
+// Get returns the Entry for the associated key or returns nil if the
+// key does not exist.
+func (d *Dtrie) Get(key interface{}) Entry {
+	return get(d.root, d.hasher(key), key)
+}
+
+// Insert adds an entry to the Dtrie, replacing the existing value if
+// the key already exists and returns the resulting Dtrie.
+func (d *Dtrie) Insert(entry Entry) *Dtrie {
+	root := insert(d.root, entry)
+	return &Dtrie{root, d.hasher}
+}
+
+// Remove deletes the value for the associated key if it exists and returns
+// the resulting Dtrie.
+func (d *Dtrie) Remove(key interface{}) *Dtrie {
+	root := remove(d.root, d.hasher(key), key)
+	return &Dtrie{root, d.hasher}
+}
+
+// Iterator returns a read-only channel of Entries from the Dtrie. If a stop
+// channel is provided, closing it will terminate and close the iterator
+// channel. Note that if a cancel channel is not used and not every entry is
+// read from the iterator, a goroutine will leak.
+func (d *Dtrie) Iterator(stop <-chan struct{}) <-chan Entry {
+	return iterate(d.root, stop)
+}

--- a/trie/dtrie/dtrie.go
+++ b/trie/dtrie/dtrie.go
@@ -53,7 +53,7 @@ func New(hasher func(v interface{}) uint32) *Dtrie {
 
 // Size returns the number of entries in the Dtrie.
 func (d *Dtrie) Size() (size int) {
-	for range iterate(d.root, nil) {
+	for _ = range iterate(d.root, nil) {
 		size++
 	}
 	return size

--- a/trie/dtrie/dtrie_test.go
+++ b/trie/dtrie/dtrie_test.go
@@ -1,0 +1,209 @@
+/*
+Copyright (c) 2016, Theodore Butler
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package dtrie
+
+import (
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPopCount(t *testing.T) {
+	b := []uint32{
+		uint32(0x55555555), // 0x55555555 = 01010101 01010101 01010101 01010101
+		uint32(0x33333333), // 0x33333333 = 00110011 00110011 00110011 00110011
+		uint32(0x0F0F0F0F), // 0x0F0F0F0F = 00001111 00001111 00001111 00001111
+		uint32(0x00FF00FF), // 0x00FF00FF = 00000000 11111111 00000000 11111111
+		uint32(0x0000FFFF), // 0x0000FFFF = 00000000 00000000 11111111 11111111
+	}
+	for _, x := range b {
+		assert.Equal(t, 16, popCount(x))
+	}
+}
+
+func TestDefaultHasher(t *testing.T) {
+	assert.Equal(t,
+		defaultHasher(map[int]string{11234: "foo"}),
+		defaultHasher(map[int]string{11234: "foo"}))
+	assert.NotEqual(t, defaultHasher("foo"), defaultHasher("bar"))
+}
+
+type testEntry struct {
+	hash  uint32
+	key   int
+	value int
+}
+
+func (e *testEntry) KeyHash() uint32 {
+	return e.hash
+}
+
+func (e *testEntry) Key() interface{} {
+	return e.key
+}
+
+func (e *testEntry) Value() interface{} {
+	return e.value
+}
+
+func (e *testEntry) String() string {
+	return fmt.Sprint(e.value)
+}
+
+func collisionHash(key interface{}) uint32 {
+	return uint32(0xffffffff) // for testing collisions
+}
+
+func TestInsert(t *testing.T) {
+	insertTest(t, defaultHasher, 10000)
+	insertTest(t, collisionHash, 1000)
+}
+
+func insertTest(t *testing.T, hashfunc func(interface{}) uint32, count int) *node {
+	n := emptyNode(0, 32)
+	for i := 0; i < count; i++ {
+		n = insert(n, &testEntry{hashfunc(i), i, i})
+	}
+	return n
+}
+
+func TestGet(t *testing.T) {
+	getTest(t, defaultHasher, 10000)
+	getTest(t, collisionHash, 1000)
+}
+
+func getTest(t *testing.T, hashfunc func(interface{}) uint32, count int) {
+	n := insertTest(t, hashfunc, count)
+	for i := 0; i < count; i++ {
+		x := get(n, hashfunc(i), i)
+		assert.Equal(t, i, x.Value())
+	}
+}
+
+func TestRemove(t *testing.T) {
+	removeTest(t, defaultHasher, 10000)
+	removeTest(t, collisionHash, 1000)
+}
+
+func removeTest(t *testing.T, hashfunc func(interface{}) uint32, count int) {
+	n := insertTest(t, hashfunc, count)
+	for i := 0; i < count; i++ {
+		n = remove(n, hashfunc(i), i)
+	}
+	for _, e := range n.entries {
+		if e != nil {
+			t.Fatal("final node is not empty")
+		}
+	}
+}
+
+func TestUpdate(t *testing.T) {
+	updateTest(t, defaultHasher, 10000)
+	updateTest(t, collisionHash, 1000)
+}
+
+func updateTest(t *testing.T, hashfunc func(interface{}) uint32, count int) {
+	n := insertTest(t, hashfunc, count)
+	for i := 0; i < count; i++ {
+		n = insert(n, &testEntry{hashfunc(i), i, -i})
+	}
+}
+
+func TestIterate(t *testing.T) {
+	n := insertTest(t, defaultHasher, 10000)
+	echan := iterate(n, nil)
+	var c int64
+	for range echan {
+		c++
+	}
+	assert.Equal(t, int64(10000), c)
+	// test with stop chan
+	c = 0
+	stop := make(chan struct{})
+	echan = iterate(n, stop)
+	go func() {
+		for range echan {
+			atomic.AddInt64(&c, 1)
+		}
+	}()
+	for atomic.LoadInt64(&c) < 100 {
+	}
+	close(stop)
+	assert.True(t, c > 99 && c < 110)
+	// test with collisions
+	n = insertTest(t, collisionHash, 1000)
+	c = 0
+	echan = iterate(n, nil)
+	for range echan {
+		c++
+	}
+	assert.Equal(t, int64(1000), c)
+}
+
+func TestSize(t *testing.T) {
+	n := insertTest(t, defaultHasher, 10000)
+	d := &Dtrie{n, defaultHasher}
+	assert.Equal(t, 10000, d.Size())
+}
+
+func BenchmarkInsert(b *testing.B) {
+	b.ReportAllocs()
+	n := emptyNode(0, 32)
+	b.ResetTimer()
+	for i := b.N; i > 0; i-- {
+		n = insert(n, &testEntry{defaultHasher(i), i, i})
+	}
+}
+
+func BenchmarkGet(b *testing.B) {
+	b.ReportAllocs()
+	n := insertTest(nil, defaultHasher, b.N)
+	b.ResetTimer()
+	for i := b.N; i > 0; i-- {
+		get(n, defaultHasher(i), i)
+	}
+}
+
+func BenchmarkRemove(b *testing.B) {
+	b.ReportAllocs()
+	n := insertTest(nil, defaultHasher, b.N)
+	b.ResetTimer()
+	for i := b.N; i > 0; i-- {
+		n = remove(n, defaultHasher(i), i)
+	}
+}
+
+func BenchmarkUpdate(b *testing.B) {
+	b.ReportAllocs()
+	n := insertTest(nil, defaultHasher, b.N)
+	b.ResetTimer()
+	for i := b.N; i > 0; i-- {
+		n = insert(n, &testEntry{defaultHasher(i), i, -i})
+	}
+}

--- a/trie/dtrie/dtrie_test.go
+++ b/trie/dtrie/dtrie_test.go
@@ -161,9 +161,9 @@ func TestIterate(t *testing.T) {
 	atomic.StoreInt64(&c, 0)
 	echan = iterate(n, nil)
 	for _ = range echan {
-		c++
+		atomic.AddInt64(&c, 1)
 	}
-	assert.Equal(t, int64(1000), c)
+	assert.Equal(t, int64(1000), atomic.LoadInt64(&c))
 }
 
 func TestSize(t *testing.T) {

--- a/trie/dtrie/dtrie_test.go
+++ b/trie/dtrie/dtrie_test.go
@@ -158,7 +158,7 @@ func TestIterate(t *testing.T) {
 	assert.True(t, c > 99 && c < 1000)
 	// test with collisions
 	n = insertTest(t, collisionHash, 1000)
-	c = 0
+	atomic.StoreInt64(&c, 0)
 	echan = iterate(n, nil)
 	for _ = range echan {
 		c++

--- a/trie/dtrie/dtrie_test.go
+++ b/trie/dtrie/dtrie_test.go
@@ -139,7 +139,7 @@ func TestIterate(t *testing.T) {
 	n := insertTest(t, defaultHasher, 10000)
 	echan := iterate(n, nil)
 	var c int64
-	for range echan {
+	for _ = range echan {
 		c++
 	}
 	assert.Equal(t, int64(10000), c)
@@ -160,7 +160,7 @@ func TestIterate(t *testing.T) {
 	n = insertTest(t, collisionHash, 1000)
 	c = 0
 	echan = iterate(n, nil)
-	for range echan {
+	for _ = range echan {
 		c++
 	}
 	assert.Equal(t, int64(1000), c)

--- a/trie/dtrie/dtrie_test.go
+++ b/trie/dtrie/dtrie_test.go
@@ -155,7 +155,8 @@ func TestIterate(t *testing.T) {
 	for atomic.LoadInt64(&c) < 100 {
 	}
 	close(stop)
-	assert.True(t, c > 99 && c < 1000)
+	cf := atomic.LoadInt64(&c)
+	assert.True(t, cf > 99 && cf < 1000)
 	// test with collisions
 	n = insertTest(t, collisionHash, 1000)
 	atomic.StoreInt64(&c, 0)

--- a/trie/dtrie/dtrie_test.go
+++ b/trie/dtrie/dtrie_test.go
@@ -148,7 +148,7 @@ func TestIterate(t *testing.T) {
 	stop := make(chan struct{})
 	echan = iterate(n, stop)
 	go func() {
-		for range echan {
+		for _ = range echan {
 			atomic.AddInt64(&c, 1)
 		}
 	}()

--- a/trie/dtrie/dtrie_test.go
+++ b/trie/dtrie/dtrie_test.go
@@ -155,7 +155,7 @@ func TestIterate(t *testing.T) {
 	for atomic.LoadInt64(&c) < 100 {
 	}
 	close(stop)
-	assert.True(t, c > 99 && c < 110)
+	assert.True(t, c > 99 && c < 1000)
 	// test with collisions
 	n = insertTest(t, collisionHash, 1000)
 	c = 0

--- a/trie/dtrie/node.go
+++ b/trie/dtrie/node.go
@@ -1,0 +1,232 @@
+/*
+Copyright (c) 2016, Theodore Butler
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package dtrie
+
+import (
+	"fmt"
+	"sync"
+)
+
+type node struct {
+	entries []Entry
+	nodeMap uint32
+	dataMap uint32
+	level   uint32 // level starts at 0
+}
+
+func (n *node) KeyHash() uint32    { return 0 }
+func (n *node) Key() interface{}   { return nil }
+func (n *node) Value() interface{} { return nil }
+
+func (n *node) String() string {
+	return fmt.Sprint(n.entries)
+}
+
+type collisionNode struct {
+	entries []Entry
+}
+
+func (n *collisionNode) KeyHash() uint32    { return 0 }
+func (n *collisionNode) Key() interface{}   { return nil }
+func (n *collisionNode) Value() interface{} { return nil }
+
+func (n *collisionNode) String() string {
+	return fmt.Sprintf("<COLLISIONS %v>%v", len(n.entries), n.entries)
+}
+
+// Entry defines anything held within the data structure
+type Entry interface {
+	KeyHash() uint32
+	Key() interface{}
+	Value() interface{}
+}
+
+func emptyNode(level uint32, capacity int) *node {
+	return &node{entries: make([]Entry, capacity), level: level}
+}
+
+func insert(n *node, entry Entry) *node {
+	index := mask(entry.KeyHash(), n.level)
+	newNode := n
+	if newNode.level == 6 { // handle hash collisions on 6th level
+		if newNode.entries[index] == nil {
+			newNode.entries[index] = entry
+			newNode.dataMap = setBit(newNode.dataMap, index)
+			return newNode
+		}
+		if hasBit(newNode.dataMap, index) {
+			if newNode.entries[index].Key() == entry.Key() {
+				newNode.entries[index] = entry
+				return newNode
+			}
+			cNode := &collisionNode{entries: make([]Entry, 2)}
+			cNode.entries[0] = newNode.entries[index]
+			cNode.entries[1] = entry
+			newNode.entries[index] = cNode
+			newNode.dataMap = clearBit(newNode.dataMap, index)
+			return newNode
+		}
+		cNode := newNode.entries[index].(*collisionNode)
+		cNode.entries = append(cNode.entries, entry)
+		return newNode
+	}
+	if !hasBit(newNode.dataMap, index) && !hasBit(newNode.nodeMap, index) { // insert directly
+		newNode.entries[index] = entry
+		newNode.dataMap = setBit(newNode.dataMap, index)
+		return newNode
+	}
+	if hasBit(newNode.nodeMap, index) { // insert into sub-node
+		newNode.entries[index] = insert(newNode.entries[index].(*node), entry)
+		return newNode
+	}
+	if newNode.entries[index].Key() == entry.Key() {
+		newNode.entries[index] = entry
+		return newNode
+	}
+	// create new node with the new and exisiting entries
+	var subNode *node
+	if newNode.level == 5 { // only 2 bits left at level 6 (4 possible indicies)
+		subNode = emptyNode(newNode.level+1, 4)
+	} else {
+		subNode = emptyNode(newNode.level+1, 32)
+	}
+	subNode = insert(subNode, newNode.entries[index])
+	subNode = insert(subNode, entry)
+	newNode.dataMap = clearBit(newNode.dataMap, index)
+	newNode.nodeMap = setBit(newNode.nodeMap, index)
+	newNode.entries[index] = subNode
+	return newNode
+}
+
+// returns nil if not found
+func get(n *node, keyHash uint32, key interface{}) Entry {
+	index := mask(keyHash, n.level)
+	if hasBit(n.dataMap, index) {
+		return n.entries[index]
+	}
+	if hasBit(n.nodeMap, index) {
+		return get(n.entries[index].(*node), keyHash, key)
+	}
+	if n.level == 6 { // get from collisionNode
+		if n.entries[index] == nil {
+			return nil
+		}
+		cNode := n.entries[index].(*collisionNode)
+		for _, e := range cNode.entries {
+			if e.Key() == key {
+				return e
+			}
+		}
+	}
+	return nil
+}
+
+func remove(n *node, keyHash uint32, key interface{}) *node {
+	index := mask(keyHash, n.level)
+	newNode := n
+	if hasBit(n.dataMap, index) {
+		newNode.entries[index] = nil
+		newNode.dataMap = clearBit(newNode.dataMap, index)
+		return newNode
+	}
+	if hasBit(n.nodeMap, index) {
+		subNode := newNode.entries[index].(*node)
+		subNode = remove(subNode, keyHash, key)
+		// compress if only 1 entry exists in sub-node
+		if popCount(subNode.nodeMap) == 0 && popCount(subNode.dataMap) == 1 {
+			var e Entry
+			for i := uint32(0); i < 32; i++ {
+				if hasBit(subNode.dataMap, i) {
+					e = subNode.entries[i]
+					break
+				}
+			}
+			newNode.entries[index] = e
+			newNode.nodeMap = clearBit(newNode.nodeMap, index)
+			newNode.dataMap = setBit(newNode.dataMap, index)
+		}
+		newNode.entries[index] = subNode
+		return newNode
+	}
+	if n.level == 6 { // delete from collisionNode
+		cNode := newNode.entries[index].(*collisionNode)
+		for i, e := range cNode.entries {
+			if e.Key() == key {
+				cNode.entries = append(cNode.entries[:i], cNode.entries[i+1:]...)
+				break
+			}
+		}
+		// compress if only 1 entry exists in collisionNode
+		if len(cNode.entries) == 1 {
+			newNode.entries[index] = cNode.entries[0]
+			newNode.dataMap = setBit(newNode.dataMap, index)
+		}
+		return newNode
+	}
+	return n
+}
+
+func iterate(n *node, stop <-chan struct{}) <-chan Entry {
+	out := make(chan Entry)
+	go func() {
+		defer close(out)
+		pushEntries(n, stop, out)
+	}()
+	return out
+}
+
+func pushEntries(n *node, stop <-chan struct{}, out chan Entry) {
+	var wg sync.WaitGroup
+	for i, e := range n.entries {
+		select {
+		case <-stop:
+			return
+		default:
+			index := uint32(i)
+			switch {
+			case hasBit(n.dataMap, index):
+				out <- e
+			case hasBit(n.nodeMap, index):
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					pushEntries(e.(*node), stop, out)
+				}()
+				wg.Wait()
+			case n.level == 6 && e != nil:
+				for _, ce := range n.entries[index].(*collisionNode).entries {
+					select {
+					case <-stop:
+						return
+					default:
+						out <- ce
+					}
+				}
+			}
+		}
+	}
+}

--- a/trie/dtrie/util.go
+++ b/trie/dtrie/util.go
@@ -59,33 +59,33 @@ func popCount(bitmap uint32) int {
 }
 
 func defaultHasher(value interface{}) uint32 {
-	switch value.(type) {
+	switch v := value.(type) {
 	case uint8:
-		return uint32(value.(uint8))
+		return uint32(v)
 	case uint16:
-		return uint32(value.(uint16))
+		return uint32(v)
 	case uint32:
-		return value.(uint32)
+		return v
 	case uint64:
-		return uint32(value.(uint64))
+		return uint32(v)
 	case int8:
-		return uint32(value.(int8))
+		return uint32(v)
 	case int16:
-		return uint32(value.(int16))
+		return uint32(v)
 	case int32:
-		return uint32(value.(int32))
+		return uint32(v)
 	case int64:
-		return uint32(value.(int64))
+		return uint32(v)
 	case uint:
-		return uint32(value.(uint))
+		return uint32(v)
 	case int:
-		return uint32(value.(int))
+		return uint32(v)
 	case uintptr:
-		return uint32(value.(uintptr))
+		return uint32(v)
 	case float32:
-		return uint32(value.(float32))
+		return uint32(v)
 	case float64:
-		return uint32(value.(float64))
+		return uint32(v)
 	}
 	hasher := fnv.New32a()
 	hasher.Write([]byte(fmt.Sprintf("%#v", value)))

--- a/trie/dtrie/util.go
+++ b/trie/dtrie/util.go
@@ -1,0 +1,93 @@
+/*
+Copyright (c) 2016, Theodore Butler
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package dtrie
+
+import (
+	"fmt"
+	"hash/fnv"
+)
+
+func mask(hash, level uint32) uint32 {
+	return (hash >> (5 * level)) & 0x01f
+}
+
+func setBit(bitmap uint32, pos uint32) uint32 {
+	return bitmap | (1 << pos)
+}
+
+func clearBit(bitmap uint32, pos uint32) uint32 {
+	return bitmap & ^(1 << pos)
+}
+
+func hasBit(bitmap uint32, pos uint32) bool {
+	return (bitmap & (1 << pos)) != 0
+}
+
+func popCount(bitmap uint32) int {
+	// bit population count, see
+	// http://graphics.stanford.edu/~seander/bithacks.html#CountBitsSetParallel
+	bitmap -= (bitmap >> 1) & 0x55555555
+	bitmap = (bitmap>>2)&0x33333333 + bitmap&0x33333333
+	bitmap += bitmap >> 4
+	bitmap &= 0x0f0f0f0f
+	bitmap *= 0x01010101
+	return int(byte(bitmap >> 24))
+}
+
+func defaultHasher(value interface{}) uint32 {
+	switch value.(type) {
+	case uint8:
+		return uint32(value.(uint8))
+	case uint16:
+		return uint32(value.(uint16))
+	case uint32:
+		return value.(uint32)
+	case uint64:
+		return uint32(value.(uint64))
+	case int8:
+		return uint32(value.(int8))
+	case int16:
+		return uint32(value.(int16))
+	case int32:
+		return uint32(value.(int32))
+	case int64:
+		return uint32(value.(int64))
+	case uint:
+		return uint32(value.(uint))
+	case int:
+		return uint32(value.(int))
+	case uintptr:
+		return uint32(value.(uintptr))
+	case float32:
+		return uint32(value.(float32))
+	case float64:
+		return uint32(value.(float64))
+	}
+	hasher := fnv.New32a()
+	hasher.Write([]byte(fmt.Sprintf("%#v", value)))
+	return hasher.Sum32()
+}


### PR DESCRIPTION
This is an implementation of a persistent hash array mapped trie that expands or shrinks to provide efficient memory allocation. Details on the papers that this project is based on can be found at [github.com/theodus/dtrie](github.com/theodus/dtrie).

Benchmarks:
BenchmarkInsert-4          5000000         547 ns/op       164 B/op         2 allocs/op
BenchmarkGet-4   	        10000000       250 ns/op	       8 B/op	      1 allocs/op
BenchmarkRemove-4	10000000       253 ns/op	       8 B/op	      1 allocs/op
BenchmarkUpdate-4	5000000	       383 ns/op	       55 B/op	      3 allocs/op