### PR TITLE
README: update to point to alternative Set impls

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,11 @@ Inserts are typical BBST times at O(log n^d) where d is the number of
 dimensions.
 
 #### Set
-Self explanatory.  Could be further optimized by getting the uintptr of the
-generic interface{} used and using that as the key as Golang maps handle that
-much better than the generic struct type.
+Our Set implementation is very simple, accepts items of type `interface{}` and
+includes only a few methods. If your application requires a richer Set
+implementation over lists of type `sort.Interface`, see
+[xtgo/set](https://github.com/xtgo/set) and
+[goware/set](https://github.com/goware/set).
 
 #### Threadsafe
 A package that is meant to contain some commonly used items but in a threadsafe

--- a/set/dict.go
+++ b/set/dict.go
@@ -19,6 +19,10 @@ Package set is a simple unordered set implemented with a map.  This set
 is threadsafe which decreases performance.
 
 TODO: Actually write custom hashmap using the hash/fnv hasher.
+
+TODO: Our Set implementation Could be further optimized by getting the uintptr
+of the generic interface{} used and using that as the key; Golang maps handle
+uintptr much better than the generic interace{} key.
 */
 
 package set


### PR DESCRIPTION
Closes #104.

- Update the README to point to alternative Set implementations which may be more suitable for different use cases.
- I've also moved the TODO to the source file, where it's more relevant.

@dustinhiatt-wf @blakewilson-wf @rosshendrickson-wf @brycewilson-wf 