### PR TITLE
added queue.Peek() functionality

### DIFF
--- a/queue/error.go
+++ b/queue/error.go
@@ -26,6 +26,7 @@ var (
 	// ErrTimeout is returned when an applicable queue operation times out.
 	ErrTimeout = errors.New(`queue: poll timed out`)
 
-	// ErrUnknown is returned if the error state was unusual and unexpected.
-	ErrUnknown = errors.New(`queue: unknown error`)
+	// ErrEmptyQueue is returned when an non-applicable queue operation was called
+	// due to the queue's empty item state
+	ErrEmptyQueue = errors.New(`queue: empty queue`)
 )

--- a/queue/error.go
+++ b/queue/error.go
@@ -25,4 +25,7 @@ var (
 
 	// ErrTimeout is returned when an applicable queue operation times out.
 	ErrTimeout = errors.New(`queue: poll timed out`)
+
+	// ErrUnknown is returned if the error state was unusual and unexpected.
+	ErrUnknown = errors.New(`queue: unknown error`)
 )

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -102,7 +102,7 @@ func (items *items) peek() (interface{}, bool) {
 		return nil, false
 	}
 
-	return (*items)[length-1], true
+	return (*items)[0], true
 }
 
 func (items *items) getUntil(checker func(item interface{}) bool) []interface{} {

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -260,11 +260,11 @@ func (q *Queue) Peek() (interface{}, error) {
 	}
 
 	peekItem, ok := q.items.peek()
-	if ok {
-		return peekItem, nil
+	if !ok {
+		return nil, ErrEmptyQueue
 	}
 
-	return nil, ErrUnknown
+	return peekItem, nil
 }
 
 // TakeUntil takes a function and returns a list of items that

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -95,6 +95,16 @@ func (items *items) get(number int64) []interface{} {
 	return returnItems
 }
 
+func (items *items) peek() (interface{}, bool) {
+	length := len(*items)
+
+	if length == 0 {
+		return nil, false
+	}
+
+	return (*items)[length-1], true
+}
+
 func (items *items) getUntil(checker func(item interface{}) bool) []interface{} {
 	length := len(*items)
 
@@ -237,6 +247,24 @@ func (q *Queue) Poll(number int64, timeout time.Duration) ([]interface{}, error)
 	items = q.items.get(number)
 	q.lock.Unlock()
 	return items, nil
+}
+
+// Peek returns a the first item in the queue by value
+// without modifying the queue.
+func (q *Queue) Peek() (interface{}, error) {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+
+	if q.disposed {
+		return nil, ErrDisposed
+	}
+
+	peekItem, ok := q.items.peek()
+	if ok {
+		return peekItem, nil
+	}
+
+	return nil, ErrUnknown
 }
 
 // TakeUntil takes a function and returns a list of items that

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -329,6 +329,28 @@ func BenchmarkChannel(b *testing.B) {
 	wg.Wait()
 }
 
+func TestPeek(t *testing.T) {
+	q := New(10)
+	q.Put(`a`)
+	q.Put(`b`)
+	q.Put(`c`)
+	result, err := q.Peek()
+	expected := `c`
+
+	assert.Nil(t, err)
+	assert.Equal(t, expected, result)
+	assert.Equal(t, q.Len(), int64(3))
+}
+
+func TestPeekOnDisposedQueue(t *testing.T) {
+	q := New(10)
+	q.Dispose()
+	result, err := q.Peek()
+
+	assert.Nil(t, result)
+	assert.IsType(t, ErrDisposed, err)
+}
+
 func TestTakeUntil(t *testing.T) {
 	q := New(10)
 	q.Put(`a`, `b`, `c`)

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -334,12 +334,16 @@ func TestPeek(t *testing.T) {
 	q.Put(`a`)
 	q.Put(`b`)
 	q.Put(`c`)
-	result, err := q.Peek()
-	expected := `c`
-
+	peekResult, err := q.Peek()
+	peekExpected := `a`
 	assert.Nil(t, err)
-	assert.Equal(t, expected, result)
 	assert.Equal(t, q.Len(), int64(3))
+	assert.Equal(t, peekExpected, peekResult)
+
+	popResult, err := q.Get(1)
+	assert.Nil(t, err)
+	assert.Equal(t, peekResult, popResult[0])
+	assert.Equal(t, q.Len(), int64(2))
 }
 
 func TestPeekOnDisposedQueue(t *testing.T) {


### PR DESCRIPTION
I made a stab at implementing `Peek`. 
The Peek operation conforms to the [Wikipedia definition](https://en.wikipedia.org/wiki/Peek_(data_type_operation)): 
```
peek(D) = pop(D) 
peek(D), D = D
```
meaning "_peak_ returns the same value as _pop_", and "does not change the underlying data" (value of data after peek same as before peek).

Tests are included. 