### PR TITLE
Sort keys before deleting.

### DIFF
--- a/btree/immutable/delete.go
+++ b/btree/immutable/delete.go
@@ -28,6 +28,14 @@ func (t *Tr) DeleteItems(values ...interface{}) ([]*Item, error) {
 		keys = append(keys, &Key{Value: item.Value, Payload: item.Payload})
 	}, values...)
 
+	if err != nil {
+		return nil, err
+	}
+
+	// we need to sort the keys to ensure that a multidelete
+	// distributes deletes across a single node correctly
+	keys = keys.sort(t.config.Comparator)
+
 	err = t.delete(keys)
 	if err != nil {
 		return nil, err

--- a/btree/immutable/node.go
+++ b/btree/immutable/node.go
@@ -59,6 +59,32 @@ func (k Keys) toItems() items {
 	return items
 }
 
+func (k Keys) sort(comparator Comparator) Keys {
+	return (&keySortWrapper{comparator, k}).sort()
+}
+
+type keySortWrapper struct {
+	comparator Comparator
+	keys       Keys
+}
+
+func (sw *keySortWrapper) Len() int {
+	return len(sw.keys)
+}
+
+func (sw *keySortWrapper) Swap(i, j int) {
+	sw.keys[i], sw.keys[j] = sw.keys[j], sw.keys[i]
+}
+
+func (sw *keySortWrapper) Less(i, j int) bool {
+	return sw.comparator(sw.keys[i].Value, sw.keys[j].Value) < 0
+}
+
+func (sw *keySortWrapper) sort() Keys {
+	sort.Sort(sw)
+	return sw.keys
+}
+
 func splitKeys(keys Keys, numParts int) []Keys {
 	parts := make([]Keys, numParts)
 	for i := int64(0); i < int64(numParts); i++ {

--- a/btree/immutable/rt_test.go
+++ b/btree/immutable/rt_test.go
@@ -587,6 +587,18 @@ func TestDeleteAfterSplitIncreasing(t *testing.T) {
 	}
 }
 
+func TestDeleteMultipleLevelsRandomlyBulk(t *testing.T) {
+	num := 200
+	cfg := defaultConfig()
+	rt := New(cfg)
+	mutable := rt.AsMutable()
+	items := generateRandomItems(num)
+	mutable.AddItems(items...)
+	mutable.DeleteItems(itemsToValues(items[:100]...)...)
+	result, _ := mutable.(*Tr).toList(itemsToValues(items...)...)
+	assert.Len(t, result, 100)
+}
+
 func TestDeleteAfterSplitDecreasing(t *testing.T) {
 	num := 11
 	cfg := defaultConfig()


### PR DESCRIPTION
Fixes a potential panic in the multidelete code.

@Workiva/dtbackend 