### PR TITLE
Add HasResult to Future

### DIFF
--- a/futures/futures.go
+++ b/futures/futures.go
@@ -61,6 +61,14 @@ func (f *Future) GetResult() (interface{}, error) {
 	return f.item, f.err
 }
 
+// HasResult will return true iff the result exists
+func (f *Future) HasResult() bool {
+	f.lock.Lock()
+	hasResult := f.triggered
+	f.lock.Unlock()
+	return hasResult
+}
+
 func (f *Future) setItem(item interface{}, err error) {
 	f.lock.Lock()
 	f.triggered = true

--- a/futures/futures_test.go
+++ b/futures/futures_test.go
@@ -49,6 +49,25 @@ func TestWaitOnGetResult(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestHasResult(t *testing.T) {
+	completer := make(chan interface{})
+	f := New(completer, time.Duration(30*time.Minute))
+
+	assert.False(t, f.HasResult())
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		f.GetResult()
+		wg.Done()
+	}()
+
+	completer <- `test`
+	wg.Wait()
+
+	assert.True(t, f.HasResult())
+}
+
 func TestTimeout(t *testing.T) {
 	completer := make(chan interface{})
 	f := New(completer, time.Duration(0))


### PR DESCRIPTION
This will facilitate use cases where you want to check for a Future result and handle the situation where its not ready yet instead of blocking.
