### PR TITLE
RM-21797 Remove Gosched call limiting

### DIFF
--- a/queue/ring.go
+++ b/queue/ring.go
@@ -87,7 +87,6 @@ func (rb *RingBuffer) Offer(item interface{}) (bool, error) {
 func (rb *RingBuffer) put(item interface{}, offer bool) (bool, error) {
 	var n *node
 	pos := atomic.LoadUint64(&rb.queue)
-	i := 0
 L:
 	for {
 		if atomic.LoadUint64(&rb.disposed) == 1 {
@@ -111,12 +110,7 @@ L:
 			return false, nil
 		}
 
-		if i == 10000 {
-			runtime.Gosched() // free up the cpu before the next iteration
-			i = 0
-		} else {
-			i++
-		}
+		runtime.Gosched() // free up the cpu before the next iteration
 	}
 
 	n.data = item
@@ -141,7 +135,6 @@ func (rb *RingBuffer) Poll(timeout time.Duration) (interface{}, error) {
 	var (
 		n     *node
 		pos   = atomic.LoadUint64(&rb.dequeue)
-		i     = 0
 		start time.Time
 	)
 	if timeout > 0 {
@@ -170,12 +163,7 @@ L:
 			return nil, ErrTimeout
 		}
 
-		if i == 10000 {
-			runtime.Gosched() // free up the cpu before the next iteration
-			i = 0
-		} else {
-			i++
-		}
+		runtime.Gosched() // free up the cpu before the next iteration
 	}
 	data := n.data
 	n.data = nil


### PR DESCRIPTION
Currently `RingBuffer` limits the calls to `runtime.Gosched()` to every 10,000 loop iterations in `Put`/`Get`, presumably because it used to be more expensive in earlier versions of Go. However, running benchmarks on a contended `RingBuffer` with go1.8.3 shows a significant scalability improvement when the `Gosched` throttling is removed (see below).

![rb](https://user-images.githubusercontent.com/552817/28350863-783c4054-6c11-11e7-9919-3abd2eb5e6a6.png)

```
go version go1.8.3 linux/amd64

benchmark                             old ns/op     new ns/op     delta
BenchmarkRBLifeCycle-2                93.5          91.8          -1.82%
BenchmarkRBLifeCycle-4                83.3          91.3          +9.60%
BenchmarkRBLifeCycle-6                84.8          90.1          +6.25%
BenchmarkRBLifeCycle-8                84.3          89.6          +6.29%
BenchmarkRBLifeCycle-10               86.1          90.3          +4.88%
BenchmarkRBLifeCycle-12               83.8          90.1          +7.52%
BenchmarkRBLifeCycle-14               84.4          90.2          +6.87%
BenchmarkRBLifeCycle-16               84.9          90.1          +6.12%
BenchmarkRBLifeCycleContention-2      1043          638           -38.83%
BenchmarkRBLifeCycleContention-4      2464          1160          -52.92%
BenchmarkRBLifeCycleContention-6      3117          1278          -59.00%
BenchmarkRBLifeCycleContention-8      3472          1317          -62.07%
BenchmarkRBLifeCycleContention-10     3452          1349          -60.92%
BenchmarkRBLifeCycleContention-12     3481          1494          -57.08%
BenchmarkRBLifeCycleContention-14     3467          1675          -51.69%
BenchmarkRBLifeCycleContention-16     3515          1772          -49.59%
BenchmarkRBPut-2                      50.8          49.7          -2.17%
BenchmarkRBPut-4                      62.5          62.1          -0.64%
BenchmarkRBPut-6                      57.2          56.9          -0.52%
BenchmarkRBPut-8                      58.0          57.4          -1.03%
BenchmarkRBPut-10                     55.0          54.7          -0.55%
BenchmarkRBPut-12                     54.5          57.5          +5.50%
BenchmarkRBPut-14                     55.1          57.5          +4.36%
BenchmarkRBPut-16                     58.8          54.3          -7.65%
BenchmarkRBGet-2                      26.4          26.1          -1.14%
BenchmarkRBGet-4                      26.4          26.1          -1.14%
BenchmarkRBGet-6                      26.4          26.1          -1.14%
BenchmarkRBGet-8                      26.4          26.1          -1.14%
BenchmarkRBGet-10                     26.4          26.1          -1.14%
BenchmarkRBGet-12                     26.4          26.1          -1.14%
BenchmarkRBGet-14                     26.4          26.1          -1.14%
BenchmarkRBGet-16                     26.4          26.1          -1.14%
```

@stevenosborne-wf @brianshannan-wf @charliestrawn-wf 
cc @dzyp 