### PR TITLE
RM-22582 Dependency tracking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,20 @@
 language: go
 
 go:
-  - 1.3
-  - 1.4
+  - 1.7
+  - 1.8
   - tip
 
 before_install: go get golang.org/x/tools/cmd/cover
-script: go test -race -v -cover ./...
+
+install:
+- go get github.com/Masterminds/glide
+- glide install
+
+script: go test -race -v -cover $(glide novendor)
 
 env:
-- GOMAXPROCS=8
-- GORACE="halt_on_error=1"
+- GOMAXPROCS=8 GORACE="halt_on_error=1"
 
 notifications:
   email: false

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,12 @@
+package: github.com/Workiva/go-datastructures
+import:
+- package: github.com/satori/go.uuid
+  version: ^1.1.0
+- package: github.com/stretchr/testify
+  version: ^1.1.4
+  subpackages:
+  - mock
+- package: github.com/tinylib/msgp
+  version: ^1.0.2
+  subpackages:
+  - msgp

--- a/smithy.yaml
+++ b/smithy.yaml
@@ -5,3 +5,7 @@ runner_image: drydock-prod.workiva.net/workiva/smithy-runner-golang:121185
 
 script:
     - glide install
+
+artifacts:
+  dependencies:
+    - glide.lock

--- a/smithy.yaml
+++ b/smithy.yaml
@@ -1,0 +1,7 @@
+project: go-datastructures
+language: golang
+
+runner_image: drydock-prod.workiva.net/workiva/smithy-runner-golang:121185
+
+script:
+    - glide install


### PR DESCRIPTION
A requirement from Release Management is that dependencies are trackable. The easiest way to do this was use smithy/glide. I don't think any tests have to actually be executed in smithy, just a glide.lock generated, so I left tests in travis where non-workiva people could see them.

I also updated the go versions in travis to newer versions; as well as changed the environment variable setup to be one build with both variables instead of two builds with one environment variables each.

@stevenosborne-wf @dustinhiatt-wf 
@travisreed-wf Can you verify this satisfies RM requirements?