### PR TITLE
RM-25125 Fix non aligned read

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -143,7 +143,6 @@ func (c *cache) Remove(keys ...string) {
 	}
 }
 
-// Size returns the current size of the cache.  This method is threadsafe.
 func (c *cache) Size() uint64 {
 	c.Lock()
 	defer c.Unlock()

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -143,7 +143,11 @@ func (c *cache) Remove(keys ...string) {
 	}
 }
 
+// Size returns the current size of the cache.  This method is threadsafe.
 func (c *cache) Size() uint64 {
+	c.Lock()
+	defer c.Unlock()
+
 	return c.size
 }
 


### PR DESCRIPTION
@tomdeering-wf Reading `size` is ok on 64 bit archs, but this code might be running on 32 bit archs where this read would not be atomic.  While is is going to incur some performance overhead, it ensures that reads on any arch is atomic.

@tomdeering-wf @matthinrichsen-wf @travissanderson-wf 