### PR TITLE
RM-25125 Fix #183

### DIFF
--- a/queue/priority_queue.go
+++ b/queue/priority_queue.go
@@ -76,7 +76,7 @@ func (items *priorityItems) pop() Item {
 func (items *priorityItems) get(number int) []Item {
 	returnItems := make([]Item, 0, number)
 	for i := 0; i < number; i++ {
-		if i >= len(*items) {
+		if len(*items) == 0 {
 			break
 		}
 


### PR DESCRIPTION
```
pq.Get(x)
```
where `pq` is a priority queue and `x` is equal or greater than `pq.Len()` returns only `pq.Len()/2` elements.