### PR TITLE
RM-25125 Fixes #187: Update to the new go.uuid API

### DIFF
--- a/btree/immutable/node.go
+++ b/btree/immutable/node.go
@@ -120,7 +120,7 @@ func (n *Node) copy() *Node {
 	copy(cpKeys, n.ChildKeys)
 
 	return &Node{
-		ID:          uuid.NewV4().Bytes(),
+		ID:          uuid.Must(uuid.NewV4()).Bytes(),
 		IsLeaf:      n.IsLeaf,
 		ChildValues: cpValues,
 		ChildKeys:   cpKeys,
@@ -297,7 +297,7 @@ func (n *Node) deleteKeyAt(i int) {
 func (n *Node) splitLeafAt(i int) (interface{}, *Node) {
 	left := newNode()
 	left.IsLeaf = n.IsLeaf
-	left.ID = uuid.NewV4().Bytes()
+	left.ID = uuid.Must(uuid.NewV4()).Bytes()
 
 	value := n.ChildValues[i]
 	leftValues := make([]interface{}, i+1)
@@ -320,7 +320,7 @@ func (n *Node) splitLeafAt(i int) (interface{}, *Node) {
 func (n *Node) splitInternalAt(i int) (interface{}, *Node) {
 	left := newNode()
 	left.IsLeaf = n.IsLeaf
-	left.ID = uuid.NewV4().Bytes()
+	left.ID = uuid.Must(uuid.NewV4()).Bytes()
 	value := n.ChildValues[i]
 	leftValues := make([]interface{}, i)
 	copy(leftValues, n.ChildValues[:i])
@@ -421,7 +421,7 @@ func nodeFromBytes(t *Tr, data []byte) (*Node, error) {
 // IsLeaf is false by default.
 func newNode() *Node {
 	return &Node{
-		ID: uuid.NewV4().Bytes(),
+		ID: uuid.Must(uuid.NewV4()).Bytes(),
 	}
 }
 

--- a/btree/immutable/rt.go
+++ b/btree/immutable/rt.go
@@ -149,7 +149,7 @@ func (t *Tr) Len() int {
 func (t *Tr) AsMutable() MutableTree {
 	return &Tr{
 		Count:     t.Count,
-		UUID:      uuid.NewV4().Bytes(),
+		UUID:      uuid.Must(uuid.NewV4()).Bytes(),
 		Root:      t.Root,
 		config:    t.config,
 		cacher:    t.cacher,
@@ -197,7 +197,7 @@ func treeFromBytes(p Persister, data []byte, comparator Comparator) (*Tr, error)
 func newTree(cfg Config) *Tr {
 	return &Tr{
 		config: cfg,
-		UUID:   uuid.NewV4().Bytes(),
+		UUID:   uuid.Must(uuid.NewV4()).Bytes(),
 		cacher: newCacher(cfg.Persister),
 	}
 }

--- a/btree/immutable/rt_test.go
+++ b/btree/immutable/rt_test.go
@@ -220,7 +220,7 @@ func generateRandomQuery() (interface{}, interface{}) {
 func newItem(value interface{}) *Item {
 	return &Item{
 		Value:   value,
-		Payload: uuid.NewV4().Bytes(),
+		Payload: uuid.Must(uuid.NewV4()).Bytes(),
 	}
 }
 


### PR DESCRIPTION
Fixes #187. May or may not be worthwhile to merge this until it's clear whether or not the
breaking change upstream will be reverted. Hopefully if it's reverted it's done
in a backward-compatible way for those who already worked around it, if
possible.