### PR TITLE
btree: remove dependency on github.com/satori/go.uuid

### DIFF
--- a/btree/immutable/node.go
+++ b/btree/immutable/node.go
@@ -19,10 +19,21 @@ limitations under the License.
 package btree
 
 import (
+	"crypto/rand"
+	"io"
 	"sort"
-
-	"github.com/satori/go.uuid"
 )
+
+func newID() []byte {
+	id := make([]byte, 16)
+	_, err := io.ReadFull(rand.Reader, id)
+	if err != nil {
+		// This can't happen unless the system is badly
+		// configured, like /dev/urandom isn't readable.
+		panic("reading random: " + err.Error())
+	}
+	return id
+}
 
 // ID exists because i'm tired of writing []byte
 type ID []byte
@@ -120,7 +131,7 @@ func (n *Node) copy() *Node {
 	copy(cpKeys, n.ChildKeys)
 
 	return &Node{
-		ID:          uuid.NewV4().Bytes(),
+		ID:          newID(),
 		IsLeaf:      n.IsLeaf,
 		ChildValues: cpValues,
 		ChildKeys:   cpKeys,
@@ -297,7 +308,7 @@ func (n *Node) deleteKeyAt(i int) {
 func (n *Node) splitLeafAt(i int) (interface{}, *Node) {
 	left := newNode()
 	left.IsLeaf = n.IsLeaf
-	left.ID = uuid.NewV4().Bytes()
+	left.ID = newID()
 
 	value := n.ChildValues[i]
 	leftValues := make([]interface{}, i+1)
@@ -320,7 +331,7 @@ func (n *Node) splitLeafAt(i int) (interface{}, *Node) {
 func (n *Node) splitInternalAt(i int) (interface{}, *Node) {
 	left := newNode()
 	left.IsLeaf = n.IsLeaf
-	left.ID = uuid.NewV4().Bytes()
+	left.ID = newID()
 	value := n.ChildValues[i]
 	leftValues := make([]interface{}, i)
 	copy(leftValues, n.ChildValues[:i])
@@ -421,7 +432,7 @@ func nodeFromBytes(t *Tr, data []byte) (*Node, error) {
 // IsLeaf is false by default.
 func newNode() *Node {
 	return &Node{
-		ID: uuid.NewV4().Bytes(),
+		ID: newID(),
 	}
 }
 

--- a/btree/immutable/rt.go
+++ b/btree/immutable/rt.go
@@ -18,11 +18,7 @@ limitations under the License.
 
 package btree
 
-import (
-	"sync"
-
-	"github.com/satori/go.uuid"
-)
+import "sync"
 
 // context is used to keep track of the nodes in this mutable
 // that have been created.  This is basically any node that had
@@ -149,7 +145,7 @@ func (t *Tr) Len() int {
 func (t *Tr) AsMutable() MutableTree {
 	return &Tr{
 		Count:     t.Count,
-		UUID:      uuid.NewV4().Bytes(),
+		UUID:      newID(),
 		Root:      t.Root,
 		config:    t.config,
 		cacher:    t.cacher,
@@ -197,7 +193,7 @@ func treeFromBytes(p Persister, data []byte, comparator Comparator) (*Tr, error)
 func newTree(cfg Config) *Tr {
 	return &Tr{
 		config: cfg,
-		UUID:   uuid.NewV4().Bytes(),
+		UUID:   newID(),
 		cacher: newCacher(cfg.Persister),
 	}
 }

--- a/btree/immutable/rt_test.go
+++ b/btree/immutable/rt_test.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -220,7 +219,7 @@ func generateRandomQuery() (interface{}, interface{}) {
 func newItem(value interface{}) *Item {
 	return &Item{
 		Value:   value,
-		Payload: uuid.NewV4().Bytes(),
+		Payload: newID(),
 	}
 }
 

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,7 +1,5 @@
 package: github.com/Workiva/go-datastructures
 import:
-- package: github.com/satori/go.uuid
-  version: ^1.1.0
 - package: github.com/stretchr/testify
   version: ^1.1.4
   subpackages:


### PR DESCRIPTION
The only call was uuid.NewV4().Bytes(), which really means
"get me 16 random bytes".

uuid.NewV4 changed at some point to return an error in addition
to the UUID, which made this code no longer compile.

There's no need to depend on a uuid package to get 16 random bytes.
Do what the old package did, namely read from crypto/rand.Reader
and expect it to succeed (or else panic), but without the dependency.

Fixes #187.
Fixes #188.