### PR TITLE
Reduce RingBuffer heap allocation

### DIFF
--- a/queue/ring.go
+++ b/queue/ring.go
@@ -41,7 +41,7 @@ type node struct {
 	data     interface{}
 }
 
-type nodes []*node
+type nodes []node
 
 // RingBuffer is a MPMC buffer that achieves threadsafety with CAS operations
 // only.  A put on full or get on empty call will block until an item
@@ -64,7 +64,7 @@ func (rb *RingBuffer) init(size uint64) {
 	size = roundUp(size)
 	rb.nodes = make(nodes, size)
 	for i := uint64(0); i < size; i++ {
-		rb.nodes[i] = &node{position: i}
+		rb.nodes[i] = node{position: i}
 	}
 	rb.mask = size - 1 // so we don't have to do this with every put/get operation
 }
@@ -93,7 +93,7 @@ L:
 			return false, ErrDisposed
 		}
 
-		n = rb.nodes[pos&rb.mask]
+		n = &rb.nodes[pos&rb.mask]
 		seq := atomic.LoadUint64(&n.position)
 		switch dif := seq - pos; {
 		case dif == 0:
@@ -146,7 +146,7 @@ L:
 			return nil, ErrDisposed
 		}
 
-		n = rb.nodes[pos&rb.mask]
+		n = &rb.nodes[pos&rb.mask]
 		seq := atomic.LoadUint64(&n.position)
 		switch dif := seq - (pos + 1); {
 		case dif == 0:

--- a/queue/ring_test.go
+++ b/queue/ring_test.go
@@ -396,3 +396,9 @@ func BenchmarkRBGet(b *testing.B) {
 		rb.Get()
 	}
 }
+
+func BenchmarkRBAllocation(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		NewRingBuffer(1024)
+	}
+}


### PR DESCRIPTION
Hi,

Thanks for creating this library. Great work!

It seems to me that in RingBuffer we can reduce the number of heap allocations by changing nodes
from an array of node **pointers**: `type nodes []*node`
to an array of node **values**: `type nodes []node`

It should also increase locality, cache efficiency and increase performance in theory.

As you can see the benchmark results below, this change reduced ns/op, B/ops and allocs/op of BenchmarkRBAllocation a lot, while having no significant impact on other benchmarks.

```
type nodes []*node
$ go test -bench BenchmarkRB.* -benchmem
goos: linux
goarch: amd64
pkg: github.com/chrisxue815/go-datastructures/queue
BenchmarkRBLifeCycle-8                   2000000               889 ns/op             200 B/op          3 allocs/op
BenchmarkRBLifeCycleContention-8          100000             12167 ns/op            1999 B/op         29 allocs/op
BenchmarkRBPut-8                        50000000                33.6 ns/op             8 B/op          0 allocs/op
BenchmarkRBGet-8                        100000000               12.1 ns/op             0 B/op          0 allocs/op
BenchmarkRBAllocation-8                    50000             28084 ns/op           40960 B/op       1025 allocs/op
PASS
ok      github.com/chrisxue815/go-datastructures/queue  20.987s
```

```
type nodes []node
$ go test -bench BenchmarkRB.* -benchmem
goos: linux
goarch: amd64
pkg: github.com/chrisxue815/go-datastructures/queue
BenchmarkRBLifeCycle-8                   2000000               875 ns/op             200 B/op          3 allocs/op
BenchmarkRBLifeCycleContention-8          200000             12002 ns/op            1999 B/op         29 allocs/op
BenchmarkRBPut-8                        50000000                26.6 ns/op             8 B/op          0 allocs/op
BenchmarkRBGet-8                        100000000               13.6 ns/op             0 B/op          0 allocs/op
BenchmarkRBAllocation-8                   500000              3833 ns/op           24576 B/op          1 allocs/op
PASS
ok      github.com/chrisxue815/go-datastructures/queue  16.446s
```
