### PR TITLE
Add nil check to Dtrie.Get()

### DIFF
--- a/trie/dtrie/dtrie.go
+++ b/trie/dtrie/dtrie.go
@@ -80,7 +80,11 @@ func (d *Dtrie) Size() (size int) {
 // Get returns the value for the associated key or returns nil if the
 // key does not exist.
 func (d *Dtrie) Get(key interface{}) interface{} {
-	return get(d.root, d.hasher(key), key).Value()
+    node := get(d.root, d.hasher(key), key)
+    if node != nil {
+        return node.Value()
+    }
+	return nil
 }
 
 // Insert adds a key value pair to the Dtrie, replacing the existing value if


### PR DESCRIPTION
Dtrie.Get() currently panics if called with a key that does not exist (due to calling `nil.Value()` in this case). Adding a nil check here will prevent this panic from happening, and ensure that the behaviour is as described in documentation.