### PR TITLE
ringbuffer use int64 and return false and error when put item to ful…

### DIFF
--- a/queue/error.go
+++ b/queue/error.go
@@ -29,4 +29,8 @@ var (
 	// ErrEmptyQueue is returned when an non-applicable queue operation was called
 	// due to the queue's empty item state
 	ErrEmptyQueue = errors.New(`queue: empty queue`)
+
+	// ErrFullQueue is returned when an non-applicable queue operation was called
+	// due to the queue's full item state
+	ErrFullQueue = errors.New(`queue: full queue`)
 )


### PR DESCRIPTION
when producer are put faster then consumer, the ringbuffer will be full.  put function will infinite loop.
switch dif := seq - pos will always gt 0 so alway case default, this infinite loop is a cpu hog