### PR TITLE
add retention to upload

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -56,6 +56,7 @@ jobs:
         with:
           name: go-datastructures test go ${{ matrix.go }}
           path: ./artifacts/tests_go_version-${{ matrix.go }}.xml
+          retention-days: 7
 
       - uses: anchore/sbom-action@v0
         with:


### PR DESCRIPTION
If this is unset, it falls back to the repo default.
I don't have the power to change that. 

Workiva policy is 7 days for non-release artifacts, and 30 for release. Set to 7. 