### PR TITLE
ringbuffer: dif is never less than zero

### DIFF
--- a/queue/ring.go
+++ b/queue/ring.go
@@ -100,8 +100,6 @@ L:
 			if atomic.CompareAndSwapUint64(&rb.queue, pos, pos+1) {
 				break L
 			}
-		case dif < 0:
-			panic(`Ring buffer in a compromised state during a put operation.`)
 		default:
 			pos = atomic.LoadUint64(&rb.queue)
 		}


### PR DESCRIPTION
Since dif is of type uint64, it can never be less than 0. Instead, when attempting to put an item into a full queue or get an item from an empty queue, dif overflows in the mod calculation manner (e.g., -1 mod 2^64 becomes 18446744073709551615). For clean code, I think it might be better to remove the unreachable code. 