### PR TITLE
Differentiate naming convention

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -59,7 +59,7 @@ jobs:
           retention-days: 7
 
       - uses: anchore/sbom-action@v0
-        id: go-${{ matrix.go }}
         with:
           path: ./  
           format: cyclonedx-json
+          artifact-name: ${{ matrix.go }}-sbom.spdx

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -62,3 +62,4 @@ jobs:
         with:
           path: ./  
           format: cyclonedx-json
+          id: go-${{ matrix.go }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -59,7 +59,7 @@ jobs:
           retention-days: 7
 
       - uses: anchore/sbom-action@v0
+        id: go-${{ matrix.go }}
         with:
           path: ./  
           format: cyclonedx-json
-          id: go-${{ matrix.go }}


### PR DESCRIPTION
The previous workflow was failing due to a collision in the artifacts being uploaded. Differentiate