### PR TITLE
Faster hilbert.Encode and hilbert.Decode

### DIFF
--- a/numerics/hilbert/hilbert.go
+++ b/numerics/hilbert/hilbert.go
@@ -26,8 +26,8 @@ This expects coordinates in the range [0, 0] to [MaxInt32, MaxInt32].
 Using negative values for x and y will have undefinied behavior.
 
 Benchmarks:
-BenchmarkEncode-8	10000000	       181 ns/op
-BenchmarkDecode-8	10000000	       191 ns/op
+BenchmarkEncode-10    	23791095	        50.66 ns/op
+BenchmarkDecode-10    	32430058	        36.99 ns/op
 */
 package hilbert
 

--- a/numerics/hilbert/hilbert.go
+++ b/numerics/hilbert/hilbert.go
@@ -44,7 +44,7 @@ func boolToInt(value bool) int32 {
 	return int32(0)
 }
 
-func rotate(n, rx, ry int32, x, y int32) (int32, int32) {
+func rotate(n, rx, ry, x, y int32) (int32, int32) {
 	if ry == 0 {
 		if rx == 1 {
 			x = n - 1 - x

--- a/numerics/hilbert/hilbert.go
+++ b/numerics/hilbert/hilbert.go
@@ -64,7 +64,7 @@ func Encode(x, y int32) int64 {
 	for s := int32(n >> 1); s > 0; s >>= 1 {
 		rx = boolToInt(x&s > 0)
 		ry = boolToInt(y&s > 0)
-		d += int64(int64(s) * int64(s) * int64(((3 * rx) ^ ry)))
+		d += int64(int64(s) * int64(s) * int64(rx<<1|(rx^ry)))
 		x, y = rotate(s, rx, ry, x, y)
 	}
 
@@ -79,7 +79,7 @@ func Decode(h int64) (int32, int32) {
 	t := h
 
 	for s := int64(1); s < int64(n); s <<= 1 {
-		rx = 1 & (t / 2)
+		rx = 1 & (t >> 1)
 		ry = 1 & (t ^ rx)
 		x, y = rotate(int32(s), int32(rx), int32(ry), x, y)
 		x += int32(s * rx)

--- a/numerics/hilbert/hilbert.go
+++ b/numerics/hilbert/hilbert.go
@@ -44,17 +44,18 @@ func boolToInt(value bool) int32 {
 	return int32(0)
 }
 
-func rotate(n, rx, ry int32, x, y *int32) {
+func rotate(n, rx, ry int32, x, y int32) (int32, int32) {
 	if ry == 0 {
 		if rx == 1 {
-			*x = n - 1 - *x
-			*y = n - 1 - *y
+			x = n - 1 - x
+			y = n - 1 - y
 		}
 
-		t := *x
-		*x = *y
-		*y = t
+		t := x
+		x = y
+		y = t
 	}
+	return x, y
 }
 
 // Encode will encode the provided x and y coordinates into a Hilbert
@@ -62,11 +63,11 @@ func rotate(n, rx, ry int32, x, y *int32) {
 func Encode(x, y int32) int64 {
 	var rx, ry int32
 	var d int64
-	for s := int32(n / 2); s > 0; s /= 2 {
+	for s := int32(n >> 1); s > 0; s = s >> 1 {
 		rx = boolToInt(x&s > 0)
 		ry = boolToInt(y&s > 0)
 		d += int64(int64(s) * int64(s) * int64(((3 * rx) ^ ry)))
-		rotate(s, rx, ry, &x, &y)
+		x, y = rotate(s, rx, ry, x, y)
 	}
 
 	return d
@@ -82,7 +83,7 @@ func Decode(h int64) (int32, int32) {
 	for s := int64(1); s < int64(n); s *= 2 {
 		rx = 1 & (t / 2)
 		ry = 1 & (t ^ rx)
-		rotate(int32(s), int32(rx), int32(ry), &x, &y)
+		x, y = rotate(int32(s), int32(rx), int32(ry), x, y)
 		x += int32(s * rx)
 		y += int32(s * ry)
 		t /= 4

--- a/numerics/hilbert/hilbert.go
+++ b/numerics/hilbert/hilbert.go
@@ -51,9 +51,7 @@ func rotate(n, rx, ry int32, x, y int32) (int32, int32) {
 			y = n - 1 - y
 		}
 
-		t := x
-		x = y
-		y = t
+		x, y = y, x
 	}
 	return x, y
 }
@@ -63,7 +61,7 @@ func rotate(n, rx, ry int32, x, y int32) (int32, int32) {
 func Encode(x, y int32) int64 {
 	var rx, ry int32
 	var d int64
-	for s := int32(n >> 1); s > 0; s = s >> 1 {
+	for s := int32(n >> 1); s > 0; s >>= 1 {
 		rx = boolToInt(x&s > 0)
 		ry = boolToInt(y&s > 0)
 		d += int64(int64(s) * int64(s) * int64(((3 * rx) ^ ry)))
@@ -80,13 +78,13 @@ func Decode(h int64) (int32, int32) {
 	var x, y int32
 	t := h
 
-	for s := int64(1); s < int64(n); s *= 2 {
+	for s := int64(1); s < int64(n); s <<= 1 {
 		rx = 1 & (t / 2)
 		ry = 1 & (t ^ rx)
 		x, y = rotate(int32(s), int32(rx), int32(ry), x, y)
 		x += int32(s * rx)
 		y += int32(s * ry)
-		t /= 4
+		t >>= 2
 	}
 
 	return x, y


### PR DESCRIPTION
### Description
Encode/Decode can be improved.

This PR makes the following changes:
- all divisions which are powers of two converted to bit shift
- removes pointer dereferencing
- prefers bitwise operators where we can

### Results:
```
goos: darwin
goarch: arm64
pkg: github.com/Workiva/go-datastructures/numerics/hilbert
cpu: Apple M1 Max
          │  master.txt  │               pr4.txt               │
          │    sec/op    │   sec/op     vs base                │
Encode-10    78.71n ± 0%   50.64n ± 0%  -35.66% (p=0.000 n=30)
Decode-10   131.80n ± 1%   37.30n ± 0%  -71.70% (p=0.000 n=30)
geomean      101.9n        43.46n       -57.33%

          │  master.txt  │               pr4.txt               │
          │     B/op     │    B/op     vs base                 │
Encode-10   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=30) ¹
Decode-10   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=30) ¹
geomean                ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

          │  master.txt  │               pr4.txt               │
          │  allocs/op   │ allocs/op   vs base                 │
Encode-10   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=30) ¹
Decode-10   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=30) ¹
geomean                ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```