### PR TITLE
chore(dependabot): add 4-day cooldown, exempt Docker from cooldown -- Review and Merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 4
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      exclude:
+        - "*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Dependabot 4-day cooldown rollout

Automated org-wide change: adds a 4-day cooldown floor to non-Docker/OS-image ecosystems (to keep Dependabot PRs in sync with JFrog Curation's package promotion delay), and explicitly exempts `docker`/`docker-compose`/`devcontainers` from cooldown (base images come directly from DHI, not through Curation). `github-actions` entries are left completely hands-off per policy.

### Diff
```diff
diff --git a/.github/dependabot.yml b/.github/dependabot.yml
new file mode 100644
index 0000000..3185391
--- /dev/null
+++ b/.github/dependabot.yml
@@ -0,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 4
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      exclude:
+        - "*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
```

### Notes
- Ecosystems with existing `default-days` already >= 4 were left untouched (floor, not fixed value).
- `docker`/`docker-compose`/`devcontainers` entries set to `cooldown: exclude: ["*"]`.
- `github-actions` entries (if any) left completely untouched, cooldown or not.
- Existing `registries:` blocks and per-entry registry references were not modified.
- Schema-validated against the current Dependabot config schema before this PR was opened.
